### PR TITLE
Process FindClosestBoundaryLineCrossing and Version response messages

### DIFF
--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -87,6 +87,8 @@
 
 extern wxJSONValue g_ReceivedBoundaryEnterJSONMsg;
 extern wxString    g_ReceivedBoundaryEnterMessage;
+extern wxJSONValue g_ReceivedBoundaryCrossJSONMsg;
+extern wxString    g_ReceivedBoundaryCrossMessage;
 
 static double Swell(GribRecordSet *grib, double lat, double lon)
 {
@@ -929,9 +931,9 @@ bool Position::EntersBoundary(double dlat, double dlon)
     jMsg[wxS("BoundaryType")] = wxT("Exclusion");
     writer.Write( jMsg, MsgString );
     SendPluginMessage( wxS("OCPN_DRAW_PI"), MsgString );
-    if(g_ReceivedBoundaryEnterMessage != wxEmptyString &&
-        g_ReceivedBoundaryEnterJSONMsg[wxS("MsgId")].AsString() == wxS("enter") &&
-        g_ReceivedBoundaryEnterJSONMsg[wxS("Found")].AsBool() == true ) {
+    if(g_ReceivedBoundaryCrossMessage != wxEmptyString &&
+        g_ReceivedBoundaryCrossJSONMsg[wxS("MsgId")].AsString() == wxS("enter") &&
+        g_ReceivedBoundaryCrossJSONMsg[wxS("Found")].AsBool() == true ) {
         // This is our message
         return true;
     }

--- a/src/weather_routing_pi.cpp
+++ b/src/weather_routing_pi.cpp
@@ -48,6 +48,10 @@
 
 wxJSONValue g_ReceivedBoundaryEnterJSONMsg;
 wxString    g_ReceivedBoundaryEnterMessage;
+wxJSONValue g_ReceivedBoundaryCrossJSONMsg;
+wxString    g_ReceivedBoundaryCrossMessage;
+wxJSONValue g_ReceivedODVersionJSONMsg;
+wxString    g_ReceivedODVersionMessage;
 
 
 extern "C" DECL_EXP opencpn_plugin* create_pi(void *ppimgr)
@@ -351,6 +355,16 @@ void weather_routing_pi::SetPluginMessage(wxString &message_id, wxString &messag
                         g_ReceivedBoundaryEnterJSONMsg = root;
                         g_ReceivedBoundaryEnterMessage = message_body;
                     } 
+                } else if(root[wxS("Msg")].AsString() == wxS("FindClosestBoundaryLineCrossing") ) {
+                    if(root[wxS("MsgId")].AsString() == wxS("enter")) {
+                        g_ReceivedBoundaryCrossJSONMsg = root;
+                        g_ReceivedBoundaryCrossMessage = message_body;
+                    } 
+                } else if(root[wxS("Msg")].AsString() == wxS("Version") ) {
+                    if(root[wxS("MsgId")].AsString() == wxS("version")) {
+                        g_ReceivedODVersionJSONMsg = root;
+                        g_ReceivedODVersionMessage = message_body;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes up using the new FindClosestBoundaryLineCrossing JSON message. The response message was not being processed so it would never find a boundary.