### PR TITLE
Fix compiler errors under VS2013

### DIFF
--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -37,6 +37,16 @@
 #include "weather_routing_pi.h"
 #include "WeatherRouting.h"
 
+const wxString SettingsDialog::column_names[21] = {_T(""), _("Start"), _("Start Time"),
+                                                   _("End"), _("End Time"), _("Time"), _("Distance"),
+                                                   _("Avg Speed"), _("Max Speed"),
+                                                   _("Avg Speed Ground"), _("Max Speed Ground"),
+                                                   _("Avg Wind"), _("Max Wind"),
+                                                   _("Avg Current"), _("Max Current"),
+                                                   _("Avg Swell"), _("Max Swell"),
+                                                   _("Upwind Percentage"),
+                                                   _("Port Starboard"), _("Tacks"), _("State")};
+
 SettingsDialog::SettingsDialog( wxWindow *parent )
     : SettingsDialogBase(parent)
 {

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -46,15 +46,7 @@ public:
     void OnUpdate( );
     void OnUpdateColumns( wxCommandEvent& event );
     void OnHelp( wxCommandEvent& event );
-    const wxString column_names[21] = {_T(""), _("Start"), _("Start Time"),
-                                        _("End"), _("End Time"), _("Time"), _("Distance"),
-                                        _("Avg Speed"), _("Max Speed"),
-                                        _("Avg Speed Ground"), _("Max Speed Ground"),
-                                        _("Avg Wind"), _("Max Wind"),
-                                        _("Avg Current"), _("Max Current"),
-                                        _("Avg Swell"), _("Max Swell"),
-                                        _("Upwind Percentage"),
-                                        _("Port Starboard"), _("Tacks"), _("State")};
+    static const wxString column_names[21];
 
 
 };

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -79,6 +79,16 @@ static const char *eye[]={
 WeatherRoute::WeatherRoute() : routemapoverlay(new RouteMapOverlay) {}
 WeatherRoute::~WeatherRoute() { delete routemapoverlay; }
 
+ const wxString WeatherRouting::column_names[NUM_COLS] = {_T(""), _("Start"), _("Start Time"),
+                                                          _("End"), _("End Time"), _("Time"), _("Distance"),
+                                                          _("Avg Speed"), _("Max Speed"),
+                                                          _("Avg Speed Ground"), _("Max Speed Ground"),
+                                                          _("Avg Wind"), _("Max Wind"),
+                                                          _("Avg Current"), _("Max Current"),
+                                                          _("Avg Swell"), _("Max Swell"),
+                                                          _("Upwind Percentage"),
+                                                          _("Port Starboard"), _("Tacks"), _("State")};
+
 static int sortcol, sortorder = 1;
 // sort callback. Sort by body.
 #if wxCHECK_VERSION(2, 9, 0)

--- a/src/WeatherRouting.h
+++ b/src/WeatherRouting.h
@@ -68,15 +68,7 @@ public:
           AVGWIND, MAXWIND, AVGCURRENT, MAXCURRENT, AVGSWELL, MAXSWELL,
           UPWIND_PERCENTAGE, PORT_STARBOARD, TACKS, STATE, NUM_COLS};
     long columns[NUM_COLS];
-    const wxString column_names[NUM_COLS] = {_T(""), _("Start"), _("Start Time"),
-                                        _("End"), _("End Time"), _("Time"), _("Distance"),
-                                        _("Avg Speed"), _("Max Speed"),
-                                        _("Avg Speed Ground"), _("Max Speed Ground"),
-                                        _("Avg Wind"), _("Max Wind"),
-                                        _("Avg Current"), _("Max Current"),
-                                        _("Avg Swell"), _("Max Swell"),
-                                        _("Upwind Percentage"),
-                                        _("Port Starboard"), _("Tacks"), _("State")};
+    static const wxString column_names[NUM_COLS];
     int sashpos;
 
     WeatherRouting(wxWindow *parent, weather_routing_pi &plugin);


### PR DESCRIPTION
VS2013 does not accept initialization of const static members within header files. It only allows initialization once so it has to be done in the .cpp file. This is a known limitation of VS2013 although multiple initialization of static members is valid C++ and will compile under GCC. Because VS2013 is the only supported compiler for plugins running on Windows request to accept this PR. I believe the results under GCC will be identical so this PR changes no functionality. It only affects where initialization is done.