### PR TITLE
Export track leak

### DIFF
--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1777,6 +1777,11 @@ void WeatherRouting::Export(RouteMapOverlay &routemapoverlay)
     }
 
     AddPlugInTrack(newTrack);
+    // not done PlugIn_Track DTOR
+    newTrack->pWaypointList->DeleteContents( true );
+    newTrack->pWaypointList->Clear();
+
+    delete newTrack;
 
     GetParent()->Refresh();
 }


### PR DESCRIPTION
Hi,
Ocpn plugin AddPlugInTrack deep copies its argument.
delete it after copy, PlugIn_Track DTOR only delete waypoint list not its items.

Regards
Didier