### PR TITLE
Config report

### DIFF
--- a/src/ReportDialog.cpp
+++ b/src/ReportDialog.cpp
@@ -173,7 +173,7 @@ void ReportDialog::GenerateRoutesReport()
         page += _T("<p>");
         page += c.Start + _T(" ") + _("to") + _T(" ") + c.End + _T(" ") + wxString::Format
             (_T("(%ld ") + wxString(_("configurations")) + _T(")\n"), overlays.size());
-        page += _("<dt>Fastest configuration ") + fastest->StartTime().Format(_T("%x"));
+        page += _("<dt>Fastest configuration ") + fastest->StartTime().Format(_T("%x %X"));
         page += wxString(_T(" ")) + _("avg speed") + wxString::Format
             (_T(": %.2f "), fastest->RouteInfo(RouteMapOverlay::AVGSPEED))
 	    + _("knots");

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -107,7 +107,7 @@ void SettingsDialog::LoadSettings()
             m_cblFields->Append(_("Visible"));
         else
             m_cblFields->Append(_(column_names[i]));
-        pConf->Read( wxString::Format(_T("Column ") + _(column_names[i]), i), &columns[i], columns[i]);
+        pConf->Read( wxString::Format(_T("Column_") + _(column_names[i]), i), &columns[i], columns[i]);
         m_cblFields->Check(i, columns[i]);
     }
 
@@ -139,7 +139,7 @@ void SettingsDialog::SaveSettings( )
     pConf->Write( _T("ConcurrentThreads"), m_sConcurrentThreads->GetValue());
 
     for(int i=0; i<WeatherRouting::NUM_COLS; i++)
-        pConf->Write( wxString::Format(_T("Column ") + _(column_names[i]), i), m_cblFields->IsChecked(i));
+        pConf->Write( wxString::Format(_T("Column_") + _(column_names[i]), i), m_cblFields->IsChecked(i));
 
     pConf->Write( _T("UseLocalTime"), m_cbUseLocalTime->GetValue());
 


### PR DESCRIPTION
Hi,
Add configuration start time to best configuration report, make sense when all configurations start the same day.

and a small bug, at least on linux wx has issue with trailing space in config keys

Regards
Didier
