### PR TITLE
Fix 'Ordered comparison between pointer and zero' errors

### DIFF
--- a/src/Polar.cpp
+++ b/src/Polar.cpp
@@ -181,7 +181,7 @@ Polar::Polar()
 
 #define MAX_WINDSPEEDS_IN_TABLE 200
 #define MESSAGE(S) (S + wxString(_T("\n")) + wxString::FromUTF8(filename) \
-                    + (line > 0 ? (_(" line ") + wxString::Format(_T("%d"), linenum)) : _T("")))
+                    + (line > (void *)0 ? (_(" line ") + wxString::Format(_T("%d"), linenum)) : _T("")))
 #define PARSE_WARNING(S) do { if(message.empty()) message = MESSAGE(S); } while (0)
 #define PARSE_ERROR(S) do { message = _("Boat polar failed") + wxString(_T("\n")) \
                                   + MESSAGE(S); goto failed; } while (0)


### PR DESCRIPTION
preventing the build with clang on macOS