### PR TITLE
Boundaries

### DIFF
--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -154,9 +154,9 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
     SET_CONTROL_VALUE(wxString::Format(_T("%.2f"), (double)STARTTIME.GetMinute() + STARTTIME.GetSecond()/60.0),
                 m_tStartMinute, SetValue, wxString, _T(""));
 
-    SET_SPIN_VALUE(TimeStepHours, (int)((*it).dt / 3600));
-    SET_SPIN_VALUE(TimeStepMinutes, ((int)(*it).dt / 60) % 60);
-    SET_SPIN_VALUE(TimeStepSeconds, (int)(*it).dt%60);
+    SET_SPIN_VALUE(TimeStepHours, (int)((*it).DeltaTime / 3600));
+    SET_SPIN_VALUE(TimeStepMinutes, ((int)(*it).DeltaTime / 60) % 60);
+    SET_SPIN_VALUE(TimeStepSeconds, (int)(*it).DeltaTime%60);
 
     SET_CONTROL(boatFileName, m_tBoat, SetValue, wxString, _T(""));
     long l = m_tBoat->GetValue().Length();
@@ -330,7 +330,7 @@ void ConfigurationDialog::Update()
             configuration.boatFileName = m_tBoat->GetValue();
 
         if(m_sTimeStepHours->IsEnabled()) {
-            configuration.dt = 60*(60*m_sTimeStepHours->GetValue()
+            configuration.DeltaTime = 60*(60*m_sTimeStepHours->GetValue()
                                    + m_sTimeStepMinutes->GetValue())
                 + m_sTimeStepSeconds->GetValue();
         }

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -669,7 +669,7 @@ bool Position::Propagate(IsoRouteList &routelist, RouteMapConfiguration &configu
             return false;
     }
 
-    double timeseconds = configuration.dt;
+    double timeseconds = configuration.DeltaTime;
     double dist;
 
     bool first_avoid = true;
@@ -898,7 +898,7 @@ double Position::PropagateToEnd(RouteMapConfiguration &configuration, double &H,
        the maximum boat speed once, and using that before computing boat speed for
        this angle, but for now, we don't worry because propagating to the end is a
        small amount of total computation */
-    if(dist / VBG > configuration.dt / 3600.0)
+    if(dist / VBG > configuration.DeltaTime / 3600.0)
         return NAN;
     
     /* quick test first to avoid slower calculation */
@@ -1258,7 +1258,7 @@ bool IsoRoute::ApplyCurrents(GribRecordSet *grib, wxDateTime time, RouteMapConfi
 
     bool ret = false;
     Position *p = skippoints->point;
-    double timeseconds = configuration.dt;
+    double timeseconds = configuration.DeltaTime;
     do {
         double C, VC;
         if(configuration.Currents && Current(grib, configuration.ClimatologyType,
@@ -2440,7 +2440,7 @@ bool RouteMap::Propagate()
     // request the next grib
     // in a different thread (grib record averaging going in parallel)
     m_NewGrib = NULL;
-    m_NewTime += wxTimeSpan(0, 0, configuration.dt);
+    m_NewTime += wxTimeSpan(0, 0, configuration.DeltaTime);
     m_bNeedsGrib = configuration.UseGrib;
 
     Unlock();

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -796,15 +796,42 @@ bool Position::Propagate(IsoRouteList &routelist, RouteMapConfiguration &configu
            Polar::VelocityApparentWind(VB, H, VW) > configuration.MaxApparentWindKnots)
             continue;
 
-        /* landfall test */
-        if(configuration.DetectLand && CrossesLand(dlat, nrdlon)) {
-            configuration.land_crossing = true;
-            continue;
-        }
-        /* Boundary test */
-        if(configuration.DetectBoundary && EntersBoundary(dlat, dlon)) {
-            configuration.boundary_crossing = true;
-            continue;
+        if(configuration.DetectLand || configuration.DetectBoundary) {
+            double dlat1, dlon1; 
+            double bearing, dist2end;
+            double dist2test;
+
+            // it's not an error if there's boundaries after we reach destination
+            ll_gc_ll_reverse(lat, lon, configuration.EndLat, configuration.EndLon, &bearing, &dist2end);
+            if (dist2end < dist) {
+                dist2test = dist2end;
+                ll_gc_ll(lat, lon, heading_resolve(BG), dist2test, &dlat1, &dlon1);
+            }
+            else {
+                dist2test = dist;
+                dlat1 = dlat;
+                dlon1 = dlon;
+            }
+ 
+            /* landfall test */
+            if(configuration.DetectLand) {
+                double ndlon1 = dlon1;
+                if (ndlon1 > 360) {
+                    ndlon1 -360;
+                }
+                if (CrossesLand(dlat1, ndlon1)) {
+                    configuration.land_crossing = true;
+                    continue;
+                }
+            }
+
+            /* Boundary test */
+            if(configuration.DetectBoundary) {
+                if (EntersBoundary(dlat1, dlon1)) {
+                    configuration.boundary_crossing = true;
+                    continue;
+                }
+            }
         }
         /* crosses cyclone track(s)? */
         if(configuration.AvoidCycloneTracks &&

--- a/src/RouteMap.h
+++ b/src/RouteMap.h
@@ -219,6 +219,7 @@ struct RouteMapConfiguration {
     GribRecordSet *grib;
     wxDateTime time;
     bool grib_is_data_deficient, polar_failed, wind_data_failed;
+    bool land_crossing, boundary_crossing;
 };
 
 bool operator!=(const RouteMapConfiguration &c1, const RouteMapConfiguration &c2);
@@ -240,6 +241,8 @@ public:
     LOCKING_ACCESSOR(GribFailed, m_bGribFailed)
     LOCKING_ACCESSOR(PolarFailed, m_bPolarFailed)
     LOCKING_ACCESSOR(NoData, m_bNoData)
+    LOCKING_ACCESSOR(LandCrossing, m_bLandCrossing)
+    LOCKING_ACCESSOR(BoundaryCrossing, m_bBoundaryCrossing)
 
     bool Empty() { Lock(); bool empty = origin.size() == 0; Unlock(); return empty; }
     bool NeedsGrib() { Lock(); bool needsgrib = m_bNeedsGrib; Unlock(); return needsgrib; }
@@ -292,6 +295,7 @@ private:
     RouteMapConfiguration m_Configuration;
     bool m_bFinished, m_bValid;
     bool m_bReachedDestination, m_bGribFailed, m_bPolarFailed, m_bNoData;
+    bool m_bLandCrossing, m_bBoundaryCrossing;
 
     wxDateTime m_NewTime;
 };

--- a/src/RouteMap.h
+++ b/src/RouteMap.h
@@ -182,7 +182,7 @@ struct RouteMapConfiguration {
     wxString Start, End;
     wxDateTime StartTime;
 
-    double dt; /* time in seconds between propagations */
+    double DeltaTime; /* time in seconds between propagations */
 
     Boat boat;
     wxString boatFileName;

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -985,7 +985,7 @@ std::list<PlotData> &RouteMapOverlay::GetPlotData(bool cursor_route)
 
             PlotData data;
 
-            double dt = configuration.dt;
+            double dt = configuration.DeltaTime;
             data.time = (*it)->time;
 
             data.lat = pos->lat, data.lon = pos->lon;

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1589,6 +1589,15 @@ void WeatherRoute::Update(WeatherRouting *wr, bool stateonly)
                     State += _("No Data");
                     State += _T(": ");
                 }
+                if(routemapoverlay->LandCrossing()) {
+                    State += _("Land");
+                    State += _T(": ");
+                }
+                if(routemapoverlay->BoundaryCrossing()) {
+                    State += _("Boundary");
+                    State += _T(": ");
+                }
+
                 State += _("Failed");
             }
         } else {

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1233,7 +1233,7 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure)
                         configuration.StartTime = wxDateTime::Now();
             
                     configuration.End = wxString::FromUTF8(e->Attribute("End"));
-                    configuration.dt = AttributeDouble(e, "dt", 0);
+                    configuration.DeltaTime = AttributeDouble(e, "dt", 0);
             
                     configuration.boatFileName = wxString::FromUTF8(e->Attribute("Boat"));
                     if(!wxFileName::FileExists(configuration.boatFileName)) {
@@ -1347,7 +1347,7 @@ void WeatherRouting::SaveXML(wxString filename)
         c->SetAttribute("StartDate", configuration.StartTime.FormatISODate().mb_str());
         c->SetAttribute("StartTime", configuration.StartTime.FormatISOTime().mb_str());
         c->SetAttribute("End", configuration.End.mb_str());
-        c->SetAttribute("dt", configuration.dt);
+        c->SetAttribute("dt", configuration.DeltaTime);
 
         c->SetAttribute("Boat", configuration.boatFileName.ToUTF8());
 
@@ -1854,7 +1854,7 @@ void WeatherRouting::Start(RouteMapOverlay *routemapoverlay)
 
     RouteMapConfiguration configuration = routemapoverlay->GetConfiguration();
 
-    if(configuration.dt == 0) {
+    if(configuration.DeltaTime == 0) {
         wxMessageDialog mdlg(this, _("Zero Time Step is invalid"),
                              _("Weather Routing"), wxOK | wxICON_WARNING);
         mdlg.ShowModal();
@@ -2031,7 +2031,7 @@ RouteMapConfiguration WeatherRouting::DefaultConfiguration()
         configuration.StartLat = 0, configuration.StartLon = 0;
 
     configuration.StartTime = wxDateTime::Now();
-    configuration.dt = 3600;
+    configuration.DeltaTime = 3600;
 
     if(RouteMap::Positions.size() >= 2) {
         RouteMapPosition &p = *(++RouteMap::Positions.begin());


### PR DESCRIPTION
Hi

Add land an boundary to reported errors, even if it's likely they'll always be reported if enable.

Add a small  offset to distance when testing for collision, help WR not getting stuck against a boundary

Try harder to properly end routing in the last step by:
- always  enabling 'optimize tacks' so it can reach end position even if upwind.
- it's not an error if there's land or boundaries on the tested heading but after destination, slow down WR a little.

WR still can't finish in at least 2 cases, one sending it in a wild goose chase  (if WR can't come close enough of destination).

I think fixing them need some kind of backtracking and variable time/degrees steps, also need for reliable coastal start.

Regards
Didier