### PR TITLE
Error in boundary

### DIFF
--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -2601,6 +2601,7 @@ void RouteMap::Reset()
     m_NewGrib = NULL;
     m_NewTime = m_Configuration.StartTime;
     m_bNeedsGrib = m_Configuration.UseGrib;
+    m_ErrorMsg = wxEmptyString;
 
     m_bReachedDestination = false;
     m_bGribFailed = false;

--- a/src/RouteMap.h
+++ b/src/RouteMap.h
@@ -276,6 +276,17 @@ public:
     void ResetFinished() { Lock(); m_bFinished = false; Unlock(); }
     wxString LoadBoat() { return m_Configuration.boat.OpenXML(m_Configuration.boatFileName); }
 
+    // XXX Isn't wxString refcounting thread safe?
+    wxString GetError() { Lock(); wxString ret = m_ErrorMsg; Unlock(); return ret; }
+
+    void SetError(wxString msg) {
+       Lock();
+       m_ErrorMsg = msg;
+       m_bValid = false;
+       m_bFinished = false;
+       Unlock();
+    }
+
 protected:
     virtual void Clear();
     bool ReduceList(IsoRouteList &merged, IsoRouteList &routelist, RouteMapConfiguration &configuration);
@@ -291,11 +302,13 @@ protected:
     GribRecordSet *m_NewGrib;
 
 private:
-
+ 
     RouteMapConfiguration m_Configuration;
     bool m_bFinished, m_bValid;
     bool m_bReachedDestination, m_bGribFailed, m_bPolarFailed, m_bNoData;
     bool m_bLandCrossing, m_bBoundaryCrossing;
+
+    wxString m_ErrorMsg;
 
     wxDateTime m_NewTime;
 };

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1567,7 +1567,7 @@ void WeatherRoute::Update(WeatherRouting *wr, bool stateonly)
     }
 
     if(!routemapoverlay->Valid())
-        State = _("Invalid Start/End");
+        State = _("Invalid Start/End ") + routemapoverlay->GetError();
     else
     if(routemapoverlay->Running())
         State = _("Computing...");
@@ -1863,10 +1863,8 @@ void WeatherRouting::Start(RouteMapOverlay *routemapoverlay)
 
     RouteMapConfiguration configuration = routemapoverlay->GetConfiguration();
 
-    if(configuration.DeltaTime == 0) {
-        wxMessageDialog mdlg(this, _("Zero Time Step is invalid"),
-                             _("Weather Routing"), wxOK | wxICON_WARNING);
-        mdlg.ShowModal();
+    if(configuration.DeltaTime <= 0) {
+        routemapoverlay->SetError(_("Zero Time Step"));
         return;
     }
     if (configuration.DetectBoundary) {
@@ -1874,19 +1872,15 @@ void WeatherRouting::Start(RouteMapOverlay *routemapoverlay)
              ||
             m_weather_routing_pi.InBoundary(configuration.StartLat, configuration.StartLon)) 
         {
-            wxMessageDialog mdlg(this, _("Start or destination inside exclusion boundary"),
-                             _("Weather Routing"), wxOK | wxICON_WARNING);
-            mdlg.ShowModal();
+            routemapoverlay->SetError(_("inside exclusion boundary"));
             return;
         }
     }
 
     if(fabs(configuration.StartLat) > configuration.MaxLatitude ||
        fabs(configuration.EndLat) > configuration.MaxLatitude) {
-        wxMessageDialog mdlg(this, _("Start/End lies outside of Max Latitude constraint:\n\
-routing will fail"),
-                             _("Weather Routing"), wxOK | wxICON_WARNING);
-        mdlg.ShowModal();
+            routemapoverlay->SetError(_("lies outside of Max Latitude constraint"));
+            return;
     }
 
     /* initialize crossing land routine from main thread as it is

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1869,6 +1869,17 @@ void WeatherRouting::Start(RouteMapOverlay *routemapoverlay)
         mdlg.ShowModal();
         return;
     }
+    if (configuration.DetectBoundary) {
+        if (m_weather_routing_pi.InBoundary(configuration.EndLat, configuration.EndLon)
+             ||
+            m_weather_routing_pi.InBoundary(configuration.StartLat, configuration.StartLon)) 
+        {
+            wxMessageDialog mdlg(this, _("Start or destination inside exclusion boundary"),
+                             _("Weather Routing"), wxOK | wxICON_WARNING);
+            mdlg.ShowModal();
+            return;
+        }
+    }
 
     if(fabs(configuration.StartLat) > configuration.MaxLatitude ||
        fabs(configuration.EndLat) > configuration.MaxLatitude) {

--- a/src/weather_routing_pi.cpp
+++ b/src/weather_routing_pi.cpp
@@ -88,7 +88,7 @@ weather_routing_pi::weather_routing_pi(void *ppimgr)
 {
       // Create the PlugIn icons
       initialize_images();
-
+      b_in_boundary_reply = false;
       m_tCursorLatLon.Connect(wxEVT_TIMER, wxTimerEventHandler
                               ( weather_routing_pi::OnCursorLatLonTimer ), NULL, this);
 }
@@ -351,8 +351,43 @@ void weather_routing_pi::SetPluginMessage(wxString &message_id, wxString &messag
                 wxString sptr = root[_T("OD_FindClosestBoundaryLineCrossing")].AsString();
                 sscanf(sptr.To8BitData().data(), "%p", &RouteMap::ODFindClosestBoundaryLineCrossing);
             }
+            else if (root[wxS("Msg")].AsString() == wxS("FindPointInAnyBoundary") ) {
+              if (root[wxS("MsgId")].AsString() == wxS("exist")) {
+                 b_in_boundary_reply = root[wxS("Found")].AsBool() == true;
+                 if (b_in_boundary_reply)
+                    printf("collision with %s\n", (const char*)root[wxS("GUID")].AsString().mb_str());
+              }
+            }
         }
     }
+}
+
+
+// true if lat lon in any active boundary, aka we can't exit it.
+// use JSON msg rather than binary it's not time sensitive.
+bool weather_routing_pi::InBoundary(double lat, double lon)
+{
+    wxJSONValue jMsg;
+    wxJSONWriter writer;
+    wxString    MsgString;
+
+    jMsg[wxS("Source")] = wxS("WEATHER_ROUTING_PI");
+    jMsg[wxT("Type")] = wxT("Request");
+
+    jMsg[wxT("Msg")] = wxS("FindPointInAnyBoundary");
+    jMsg[wxT("MsgId")] = wxS("exist");
+
+    jMsg[wxS("lat")] = lat;
+    jMsg[wxS("lon")] = lon;
+
+    jMsg[wxS("BoundaryState")] = wxT("Active");
+    jMsg[wxS("BoundaryType")] = wxT("Exclusion");
+
+    writer.Write( jMsg, MsgString );
+    b_in_boundary_reply = false;
+    SendPluginMessage( wxS("OCPN_DRAW_PI"), MsgString );
+
+    return b_in_boundary_reply;
 }
 
 void weather_routing_pi::SetPositionFixEx(PlugIn_Position_Fix_Ex &pfix)

--- a/src/weather_routing_pi.cpp
+++ b/src/weather_routing_pi.cpp
@@ -354,8 +354,7 @@ void weather_routing_pi::SetPluginMessage(wxString &message_id, wxString &messag
             else if (root[wxS("Msg")].AsString() == wxS("FindPointInAnyBoundary") ) {
               if (root[wxS("MsgId")].AsString() == wxS("exist")) {
                  b_in_boundary_reply = root[wxS("Found")].AsBool() == true;
-                 if (b_in_boundary_reply)
-                    printf("collision with %s\n", (const char*)root[wxS("GUID")].AsString().mb_str());
+                 // if (b_in_boundary_reply) printf("collision with %s\n", (const char*)root[wxS("GUID")].AsString().mb_str());
               }
             }
         }

--- a/src/weather_routing_pi.h
+++ b/src/weather_routing_pi.h
@@ -99,6 +99,7 @@ public:
       wxString GetCommonName();
       wxString GetShortDescription();
       wxString GetLongDescription();
+      bool InBoundary(double lat, double lon);
 
       bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
       bool RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp);
@@ -128,6 +129,8 @@ private:
 
       bool LoadConfig(void);
       bool SaveConfig(void);
+
+      bool	       b_in_boundary_reply;
 
       wxFileConfig     *m_pconfig;
       wxWindow         *m_parent_window;


### PR DESCRIPTION
Hi,
Double check before starting then both start and end WP aren't inside an exclusion boundary. 
Also use configuration status column for reporting  errors, otherwise If you start multiple routes you could end with a lot of dialog boxes.

Regards
Didier  