### PR TITLE
Use a cache for grib records

### DIFF
--- a/src/RouteMap.h
+++ b/src/RouteMap.h
@@ -24,14 +24,16 @@
  */
 
 #include "wx/datetime.h"
+#include <wx/object.h>
+#include <wx/weakref.h>
 
 #include <list>
 
 #include "ODAPI.h"
+#include "GribRecordSet.h"
 
 struct RouteMapConfiguration;
 class IsoRoute;
-class GribRecordSet;
 
 typedef std::list<IsoRoute*> IsoRouteList;
 
@@ -146,11 +148,119 @@ public:
     IsoRouteList children; /* inner inverted regions */
 };
 
+// -----------------
+class WR_GribRecordSet {
+public:
+    WR_GribRecordSet(unsigned int id) : m_Reference_Time(-1), m_ID(id) {
+        for(int i=0; i<Idx_COUNT; i++) {
+            m_GribRecordPtrArray[i] = 0;
+            m_GribRecordUnref[i] = false;
+        }
+    }
+
+    virtual ~WR_GribRecordSet()
+    {
+         RemoveGribRecords();
+    }
+
+    /* copy and paste by plugins, keep functions in header */
+    void SetUnRefGribRecord(int i, GribRecord *pGR ) { 
+        assert (i >= 0 && i < Idx_COUNT);
+        if (m_GribRecordUnref[i] == true) {
+            delete m_GribRecordPtrArray[i];
+        }
+        m_GribRecordPtrArray[i] = pGR;
+        m_GribRecordUnref[i] = true;
+    }
+
+    void RemoveGribRecords( ) { 
+        for(int i=0; i<Idx_COUNT; i++) {
+            if (m_GribRecordUnref[i] == true) {
+                delete m_GribRecordPtrArray[i];
+            }
+        }
+    }
+
+    time_t m_Reference_Time;
+    unsigned int m_ID;
+
+    GribRecord *m_GribRecordPtrArray[Idx_COUNT];
+private:
+    // grib records files are stored and owned by reader mapGribRecords
+    // interpolated grib are not, keep track of them
+    bool        m_GribRecordUnref[Idx_COUNT];
+};
+
+// ------
+class Shared_GribRecordSetData: public wxRefCounter
+{
+public:
+    Shared_GribRecordSetData( WR_GribRecordSet *gribset = 0 ) : m_GribRecordSet(gribset) { }
+    Shared_GribRecordSetData( const Shared_GribRecordSetData& data ) : m_GribRecordSet(data.m_GribRecordSet) { }
+
+    void SetGribRecordSet( WR_GribRecordSet *gribset )  { m_GribRecordSet = gribset; }
+    WR_GribRecordSet * GetGribRecordSet() const { return m_GribRecordSet; }
+
+    ~Shared_GribRecordSetData();
+
+protected:
+     WR_GribRecordSet *m_GribRecordSet;
+                    
+};
+
+// ------
+class Shared_GribRecordSet: public wxTrackable
+{
+public:
+    // initializes this, assigning to the
+    // internal data pointer a new instance of Shared_GribRecordSetData
+    Shared_GribRecordSet( WR_GribRecordSet * ptr = 0 ) : m_data( new Shared_GribRecordSetData(ptr) )
+    {
+    }
+    Shared_GribRecordSet& operator =( const Shared_GribRecordSet& tocopy )
+    {
+        // shallow copy: this is just a fast copy of pointers; the real
+        // memory-consuming data which typically is stored inside
+        m_data = tocopy.m_data;
+        return *this;
+    }
+
+    void SetGribRecordSet( WR_GribRecordSet * ptr )
+    {
+        // make sure changes to this class do not affect other instances
+        // currently sharing our same refcounted data:
+        UnShare();
+        m_data->SetGribRecordSet( ptr );
+    }
+
+    WR_GribRecordSet * GetGribRecordSet() const
+    {
+       return m_data->GetGribRecordSet();
+    }
+
+    bool operator == ( const Shared_GribRecordSet& other ) const
+    {
+        if (m_data.get() == other.m_data.get())
+            return true; // this instance and the 'other' one share the same data...
+        return (m_data->GetGribRecordSet() == other.m_data->GetGribRecordSet());
+    }
+
+    wxObjectDataPtr<Shared_GribRecordSetData> m_data;
+
+protected:
+    void UnShare()
+    {
+        if (m_data->GetRefCount() == 1)
+            return;
+        m_data.reset( new Shared_GribRecordSetData( *m_data ) );
+    }
+};
+
 /* list of routes with equal time to reach */
 class IsoChron
 {
 public:
-    IsoChron(IsoRouteList r, wxDateTime t, GribRecordSet *g, bool grib_is_data_deficient);
+    IsoChron(IsoRouteList r, wxDateTime t, Shared_GribRecordSet &g, bool grib_is_data_deficient);
     ~IsoChron();
 
     void PropagateIntoList(IsoRouteList &routelist, RouteMapConfiguration &configuration);
@@ -161,7 +271,8 @@ public:
 
     IsoRouteList routes;
     wxDateTime time;
-    GribRecordSet *m_Grib;
+    Shared_GribRecordSet m_SharedGrib;
+    WR_GribRecordSet *m_Grib;
     bool m_Grib_is_data_deficient;
 };
 
@@ -216,7 +327,7 @@ struct RouteMapConfiguration {
     by about 8%.  Is it even useful?  */
 
     // parameters
-    GribRecordSet *grib;
+    WR_GribRecordSet *grib;
     wxDateTime time;
     bool grib_is_data_deficient, polar_failed, wind_data_failed;
     bool land_crossing, boundary_crossing;
@@ -248,6 +359,7 @@ public:
     bool NeedsGrib() { Lock(); bool needsgrib = m_bNeedsGrib; Unlock(); return needsgrib; }
     void RequestedGrib() { Lock(); m_bNeedsGrib=false; Unlock(); }
     void SetNewGrib(GribRecordSet *grib);
+    void SetNewGrib(WR_GribRecordSet *grib);
     wxDateTime NewTime() { Lock(); wxDateTime time =  m_NewTime; Unlock(); return time; }
     wxDateTime StartTime() { Lock(); wxDateTime time; if(origin.size()) time = origin.front()->time;
         Unlock(); return time; }
@@ -299,7 +411,8 @@ protected:
 
     IsoChronList origin; /* list of route isos in order of time */
     bool m_bNeedsGrib;
-    GribRecordSet *m_NewGrib;
+    Shared_GribRecordSet m_SharedNewGrib;
+    WR_GribRecordSet *m_NewGrib;
 
 private:
  


### PR DESCRIPTION
Hi,

This is the previous PR but compatible with current O by decoupling WR and O grib records set classes.

Until O is updated it computes its own generation key which could wrongly state that two
records from different files are the same.
snipset:
```
 // RecordRefDate is time_t and high byte is likely the same in many grib files, add some entropy
bogus_ID = tmp->getRecordRefDate () ^ (tmp->getIdCenter() << 24) ^ (tmp->getNi() << 16);

```

Regards
Didier

