### PR TITLE
fix best downwind report

### DIFF
--- a/src/ReportDialog.cpp
+++ b/src/ReportDialog.cpp
@@ -162,9 +162,13 @@ void ReportDialog::GenerateRoutesReport()
 
     wxString page;
     for(std::map<wxString, std::list<RouteMapOverlay *> >::iterator it = routes.begin();
-        it != routes.end(); it++) {
+                          it != routes.end(); it++)
+    {
         std::list<RouteMapOverlay *> overlays = it->second;
-        assert(overlays.begin() != overlays.end());
+        if (overlays.begin() == overlays.end()) {
+            // XXX not possible? but shut up compilers warnings
+            continue;
+        }
         RouteMapOverlay *first = *overlays.begin();
 
         RouteMapConfiguration c = first->GetConfiguration();
@@ -174,79 +178,59 @@ void ReportDialog::GenerateRoutesReport()
 
         /* determine fastest time */
         wxTimeSpan fastest_time;
-        RouteMapOverlay *fastest = NULL;
+        RouteMapOverlay *fastest;
+
+        std::multimap< wxTimeSpan, RouteMapOverlay * > sort_by_duration;
+        bool any_bad = false;
+        bool any_good = false;
+
         for(std::list<RouteMapOverlay *>::iterator it2 = overlays.begin(); it2 != overlays.end(); it2++) {
-            wxTimeSpan current_time = ((*it2)->EndTime() - (*it2)->StartTime());
-            if(*it2 == first || current_time < fastest_time) {
+            RouteMapOverlay *r = *it2;
+            wxTimeSpan current_time = r->EndTime() - r->StartTime();
+            sort_by_duration.insert(std::pair<wxTimeSpan, RouteMapOverlay * >(current_time , r));
+            if(r == first || current_time < fastest_time) {
                 fastest_time = current_time;
-                fastest = *it2;
+                fastest = r;
             }
-        }
-        if(fastest) {
-            page += _("<dt>Fastest configuration ") + fastest->StartTime().Format(_T("%x %X"));
-            page += wxString(_T(" ")) + _("avg speed") + wxString::Format
-                (_T(": %.2f "), fastest->RouteInfo(RouteMapOverlay::AVGSPEED))
-                + _("knots");
-        }
-
-        /* determine best times if upwind percentage is below 50 */
-        page += _T("<dt>");
-        page += _("Best Times (mostly downwind)") + wxString(_T(": "));
-
-        bool last_bad, any_bad, any_good = false, first_print = true;
-
-        wxDateTime best_time_start;
-
-        std::list<RouteMapOverlay *>::iterator it2, it2end = overlays.begin(), prev;
-        last_bad = overlays.back()->RouteInfo(RouteMapOverlay::PERCENTAGE_UPWIND) > 50;
-
-        for(it2 = overlays.begin(); it2 != overlays.end(); it2++)
-            if((*it2)->RouteInfo(RouteMapOverlay::PERCENTAGE_UPWIND) > 50) {
-                any_bad = last_bad = true;
+            if (r->RouteInfo(RouteMapOverlay::PERCENTAGE_UPWIND) > 50) {
+                any_bad = true;
             } else {
-                if(!best_time_start.IsValid() && last_bad) {
-                    best_time_start = (*it2)->StartTime();
-                    it2end = it2;
-                    it2++;
-                    break;
-                }
-                last_bad = false;
-            }
-
-        if(it2 == overlays.end())
-            it2++;
-        for(;;) {
-            if(it2 == it2end)
-                break;
-            it2++;
-            if(it2 == overlays.end())
-                it2++;
-
-            if((*it2)->RouteInfo(RouteMapOverlay::PERCENTAGE_UPWIND) > 50) {
-                if(!last_bad) {
-                    prev = it2;
-                    prev--;
-                    if(prev == overlays.end()) prev--;
-                    if(first_print)
-                        first_print = false;
-                    else
-                        page += _(" and ");
-                    page += best_time_start.Format(_T("%d %B ")) +
-                        _("to") + (*prev)->EndTime().Format(_T(" %d %B"));
-                }
-                last_bad = any_bad = true;
-            } else {
-                if(last_bad)
-                    best_time_start = (*it2)->StartTime();
-                last_bad = false;
                 any_good = true;
             }
         }
 
-        if(!any_bad)
-            page += _("any");
-        else if(!any_good)
+        page += _("<dt>Fastest configuration ") + fastest->StartTime().Format(_T("%x %X"));
+        page += wxString(_T(" ")) + _("avg speed") + wxString::Format
+            (_T(": %.2f "), fastest->RouteInfo(RouteMapOverlay::AVGSPEED))
+	    + _("knots");
+
+        /* determine best times if upwind percentage is below 50 */
+        page += _T("<dt>");
+        page += _("Best Times (mostly downwind)") + wxString(_T(": "));
+        if (any_good == false) {
+            // no downwind route
             page += _("none");
+        }
+        else if (any_bad == false) {
+            // all routes are downwind
+            page += _("any");
+        }
+        else {
+            bool first_print = true;
+
+            std::multimap< wxTimeSpan, RouteMapOverlay * >::iterator it2;
+            for(it2 = sort_by_duration.begin(); it2 != sort_by_duration.end(); it2++) {
+                RouteMapOverlay *r = it2->second;
+                if(r->RouteInfo(RouteMapOverlay::PERCENTAGE_UPWIND) <= 50) {
+                    if(first_print)
+                        first_print = false;
+                    else
+                        page += _(" and ");
+                    page += r->StartTime().Format(_T("%d %B ")) + _("to") + r->EndTime().Format(_T(" %d %B"));
+                }
+            }
+        }
+
 
         page += _T("<dt>");
         page += _("Cyclones") + wxString(_T(": "));
@@ -258,7 +242,7 @@ void ReportDialog::GenerateRoutesReport()
         int cyclonemonths[12] = {0};
         std::list<RouteMapOverlay *> cyclone_safe_routes;
         bool allsafe = true, nonesafe = true;
-        for(it2 = overlays.begin(); it2 != overlays.end(); it2++) {
+        for(std::list<RouteMapOverlay *>::iterator it2 = overlays.begin(); it2 != overlays.end(); it2++) {
             switch((*it2)->Cyclones(cyclonemonths)) {
             case -1:
                 page += _("Climatology data unavailable.");
@@ -310,7 +294,9 @@ void ReportDialog::GenerateRoutesReport()
             /* note: does not merge beginning and end of linked list for safe times,
                this sometimes might be nice, but they will be in different years. */
             bool first = true;
-            for(it2 = cyclone_safe_routes.begin(); it2 != cyclone_safe_routes.end(); it2++) {
+            for(std::list<RouteMapOverlay *>::iterator it2 = cyclone_safe_routes.begin(); it2 != cyclone_safe_routes.end();
+                        it2++)
+            {
                 if(!*it2) continue;
                 if(!first)
                     page += _(" and ");


### PR DESCRIPTION
Hi,
two things 
- if fastest is null it means overlay is empty so first is equal to list end, dereferencing it is undefined behavior. so test and skip if first is equal to end, ie empty list (impossible?).

- it seems fastest downind route code bit rote, it doesn't work and there's a lot of potential undefined behaviors with iterators.

first patch implement sort by duration without merging.
second patch merge , in my understanding it's the closest of original code logic.

Regards
didier

