### PR TITLE
Redo the configuration editor logic to really support multiple configuration editing

### DIFF
--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -126,6 +126,7 @@ void ConfigurationDialog::OnBoatFilename( wxCommandEvent& event )
         } \
     } \
     CONTROL->SETTER(allsame ? value : NULLVALUE); \
+    CONTROL->Enable(allsame); \
     } while (0)
 
 #define SET_CONTROL(FIELD, CONTROL, SETTER, TYPE, NULLVALUE) \
@@ -151,6 +152,9 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
 
     SET_CONTROL_VALUE(STARTTIME.GetDateOnly(), m_dpStartDate, SetValue, wxDateTime, wxDateTime());
     SET_CONTROL_VALUE(STARTTIME, m_tpTime, SetValue, wxDateTime, wxDateTime());
+    
+    m_bCurrentTime->Enable(m_tpTime->IsEnabled() && m_dpStartDate->IsEnabled());
+    m_bGribTime->Enable(m_tpTime->IsEnabled() && m_dpStartDate->IsEnabled());
 
     SET_SPIN_VALUE(TimeStepHours, (int)((*it).DeltaTime / 3600));
     SET_SPIN_VALUE(TimeStepMinutes, ((int)(*it).DeltaTime / 60) % 60);
@@ -280,7 +284,7 @@ void ConfigurationDialog::SetStartDateTime(wxDateTime datetime)
         configuration.FIELD = m_s##FIELD->GetValue()
 
 #define GET_CHOICE(FIELD) \
-    if(!m_c##FIELD->GetValue().empty()) \
+    if(m_c##FIELD->IsEnabled()) \
         configuration.FIELD = m_c##FIELD->GetValue();
 
 void ConfigurationDialog::Update()
@@ -299,8 +303,9 @@ void ConfigurationDialog::Update()
         GET_CHOICE(Start);
         GET_CHOICE(End);
 
-        if(m_dpStartDate->GetValue().IsValid())
-            configuration.StartTime = m_dpStartDate->GetValue();
+        if(m_dpStartDate->IsEnabled())
+            if(m_dpStartDate->GetValue().IsValid())
+                configuration.StartTime = m_dpStartDate->GetValue();
 
         if(m_tpTime->IsEnabled()) {
             configuration.StartTime.SetHour(m_tpTime->GetValue().GetHour());

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -41,6 +41,8 @@
 #include "WeatherRouting.h"
 #include "icons.h"
 
+#include <algorithm>
+
 ConfigurationDialog::ConfigurationDialog(WeatherRouting &weatherrouting)
 #ifndef __WXOSX__
     : ConfigurationDialogBase(&weatherrouting),
@@ -126,7 +128,7 @@ void ConfigurationDialog::OnBoatFilename( wxCommandEvent& event )
         } \
     } \
     CONTROL->SETTER(allsame ? value : NULLVALUE); \
-    CONTROL->Enable(allsame); \
+    /*CONTROL->Enable(allsame);*/ \
     } while (0)
 
 #define SET_CONTROL(FIELD, CONTROL, SETTER, TYPE, NULLVALUE) \
@@ -143,6 +145,8 @@ void ConfigurationDialog::OnBoatFilename( wxCommandEvent& event )
 void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> configurations)
 {
     m_bBlockUpdate = true;
+    
+    m_edited_controls.clear();
 
     SET_CHOICE(Start);
 
@@ -279,11 +283,11 @@ void ConfigurationDialog::SetStartDateTime(wxDateTime datetime)
            } while(0)
 
 #define GET_SPIN(FIELD) \
-    if(m_s##FIELD->IsEnabled())                                      \
+    if(std::find(m_edited_controls.begin(), m_edited_controls.end(), (wxObject*)m_s##FIELD) != m_edited_controls.end())                                      \
         configuration.FIELD = m_s##FIELD->GetValue()
 
 #define GET_CHOICE(FIELD) \
-    if(m_c##FIELD->IsEnabled()) \
+    if(std::find(m_edited_controls.begin(), m_edited_controls.end(), (wxObject*)m_c##FIELD) != m_edited_controls.end()) \
         configuration.FIELD = m_c##FIELD->GetValue();
 
 void ConfigurationDialog::Update()
@@ -302,11 +306,11 @@ void ConfigurationDialog::Update()
         GET_CHOICE(Start);
         GET_CHOICE(End);
 
-        if(m_dpStartDate->IsEnabled())
+        if(std::find(m_edited_controls.begin(), m_edited_controls.end(), (wxObject*)m_dpStartDate) != m_edited_controls.end())
             if(m_dpStartDate->GetValue().IsValid())
                 configuration.StartTime = m_dpStartDate->GetValue();
 
-        if(m_tpTime->IsEnabled()) {
+        if(std::find(m_edited_controls.begin(), m_edited_controls.end(), (wxObject*)m_tpTime) != m_edited_controls.end()) {
             configuration.StartTime.SetHour(m_tpTime->GetValue().GetHour());
             configuration.StartTime.SetMinute(m_tpTime->GetValue().GetMinute());
             configuration.StartTime.SetSecond(m_tpTime->GetValue().GetSecond());

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -135,8 +135,7 @@ void ConfigurationDialog::OnBoatFilename( wxCommandEvent& event )
 #define SET_CHOICE(FIELD) SET_CONTROL(FIELD, m_c##FIELD, SetValue, wxString, _T(""))
 
 #define SET_SPIN_VALUE(FIELD, VALUE)                                          \
-    m_s##FIELD->Enable(); \
-    SET_CONTROL_VALUE(VALUE, m_s##FIELD, SetValue, int, (m_s##FIELD->Disable(), value))
+    SET_CONTROL_VALUE(VALUE, m_s##FIELD, SetValue, int, value)
 
 #define SET_SPIN(FIELD) \
     SET_SPIN_VALUE(FIELD, (*it).FIELD)

--- a/src/ConfigurationDialog.h
+++ b/src/ConfigurationDialog.h
@@ -32,6 +32,8 @@
 
 #include "WeatherRoutingUI.h"
 
+#include <vector>
+
 class WeatherRouting;
 class weather_routing_pi;
 
@@ -53,13 +55,14 @@ public:
     wxDateTime m_GribTimelineTime;
 
 protected:
-    void OnUpdate( wxCommandEvent& event ) { Update(); }
+    void OnValueChange ( wxEvent& event ) { m_edited_controls.push_back(event.GetEventObject()); }
+    void OnUpdate( wxCommandEvent& event ) { OnValueChange(event); Update(); }
     void OnResetAdvanced( wxCommandEvent& event );
-    void OnUpdateDate( wxDateEvent& event ) { Update(); }
-    void OnUpdateTime( wxDateEvent& event ) { Update(); }
+    void OnUpdateDate( wxDateEvent& event ) { OnValueChange(event); Update(); }
+    void OnUpdateTime( wxDateEvent& event ) { OnValueChange(event); Update(); }
     void OnGribTime( wxCommandEvent& event );
     void OnCurrentTime( wxCommandEvent& event );
-    void OnUpdateSpin( wxSpinEvent& event ) { Update(); }
+    void OnUpdateSpin( wxSpinEvent& event ) { OnValueChange(event); Update(); }
     void OnBoatFilename( wxCommandEvent& event );
     void OnEditBoat( wxCommandEvent& event ) { EditBoat(); }
     void OnUpdateIntegratorNewton( wxCommandEvent& event );
@@ -86,6 +89,8 @@ private:
 
     WeatherRouting &m_WeatherRouting;
     bool m_bBlockUpdate;
+    
+    std::vector<wxObject*> m_edited_controls;
 };
 
 #endif


### PR DESCRIPTION
in a way intended by the original implementation (I think).

Fixes #149 and also the bugs and oddities of the original implementation that relied on hacks and broken behaviour of older wxWidgets versions that is fixed in wx3.1.

There remains one UX issue that AFAICT can't be fixed in a satisfactory way while letting the user edit the fields at the same time - we can't set the spin controls and pickers (And combos, but there it would be fixable to certain degree by adding an invalid and inconsistent empty string choice) to an empty value. Maybe it could be somewhat improved by setting a different background colour to the fields that have non-uniform values, but that's probably all.