### PR TITLE
When a new WR version is installed, ask the user whether to copy new boats and polars.

### DIFF
--- a/src/WeatherRouting.h
+++ b/src/WeatherRouting.h
@@ -119,6 +119,7 @@ public:
     SettingsDialog m_SettingsDialog;
 
 private:
+    void CopyDataFiles(wxString from, wxString to);
     void OnCollPaneChanged( wxCollapsiblePaneEvent& event );
     void OnNewPosition( wxCommandEvent& event );
     void OnUpdateBoat( wxCommandEvent& event );


### PR DESCRIPTION
Weather Routing PI distributes a set of sample polars, boats, as well as
an example configuration giving a set of data allowing newcomers to just click
"Compute" and have a working route.

These polars, boats and example configuration needs to be installed in the
user directory, because the user will want to modify them at some point.

Prior to this commit, the copy of the data occured only one time, if the
plugin detected that the Weather Routing PI was never launched before (no
configuration file available).

Now, each time a new version of the plugin is installed:
- if the polar or boat directories do not exist in the user directory, polars
and boats are copied without prompt
- if the directories exist, the user is prompted with the choice to copy the
data or not (he can choose not to, because he has done local changes and doesn't
want those to be overwritten).

This dialog is shown only once, unless the user clicks on "Cancel" causing
the dialog to be shown again on the next launch.

In order to know if the dialog has been shown, the plugin uses the ConfigVersion
key in the PlugIns/WeatherRouting section of OpenCPN configuration file.
The value of this key is equal to PLUGIN_VERSION_MAJOR * 100 + PLUGIN_VERSION_MINOR.

Removing this key from the configuration file will cause the dialog to be
shown at the next launch of WR.