### PR TITLE
Trivial fix

### DIFF
--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1116,6 +1116,7 @@ void WeatherRouting::OnFilter( wxCommandEvent& event )
 
 void WeatherRouting::OnResetAll( wxCommandEvent& event )
 {
+    m_StatisticsDialog.SetRunTime(m_RunTime = wxTimeSpan(0));
     Reset();
     UpdateStates();
 }

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1314,8 +1314,10 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure)
         int i=0;
         for(TiXmlElement* e = root.FirstChild().Element(); e; e = e->NextSiblingElement(), i++) {
             if(progressdialog) {
-                if(!progressdialog->Update(i))
+                if(!progressdialog->Update(i)) {
+                    delete progressdialog;
                     return true;
+                }
             } else {
                 wxDateTime now = wxDateTime::UNow();
                 /* if it's going to take more than a half second, show a progress dialog */
@@ -1434,6 +1436,7 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure)
     return true;
 failed:
 
+    delete progressdialog;
     if(reportfailure) {
         wxMessageDialog mdlg(this, error, _("Weather Routing"), wxOK | wxICON_ERROR);
         mdlg.ShowModal();

--- a/src/weather_routing_pi.cpp
+++ b/src/weather_routing_pi.cpp
@@ -140,6 +140,7 @@ int weather_routing_pi::Init(void)
 
 bool weather_routing_pi::DeInit(void)
 {
+    m_tCursorLatLon.Stop();
     if(m_pWeather_Routing)
         m_pWeather_Routing->Close();
     WeatherRouting *wr = m_pWeather_Routing;
@@ -461,6 +462,9 @@ bool weather_routing_pi::RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort 
 
 void weather_routing_pi::OnCursorLatLonTimer( wxTimerEvent & )
 {
+    if (m_pWeather_Routing == 0)
+        return;
+
     std::list<RouteMapOverlay *>routemapoverlays = m_pWeather_Routing->CurrentRouteMaps();
     bool refresh = false;
     for(std::list<RouteMapOverlay *>::iterator it = routemapoverlays.begin();


### PR DESCRIPTION
Hi,
- Always delete progress dialog box in openXML or it lingers with a lot of bad side effects. 
Note: on linux with xfce if the progress dialog is triggered the first time you open WR when it reads its xml configuration file then the main dialog box size is very small.

- On reset all also reset global time in statistic dialog.

Regards
Didier
