### PR TITLE
Add wind barbs on the weather route

### DIFF
--- a/src/LineBufferOverlay.cpp
+++ b/src/LineBufferOverlay.cpp
@@ -104,6 +104,8 @@ void WindBarbLineBuffer::pushTriangle( int b )
 }
 
 LineBufferOverlay g_LineBufferOverlay;
+// Customization WindBarbsOnRoute
+LineBufferOverlay g_barbsOnRoute_LineBufferOverlay;
 
 LineBufferOverlay::LineBufferOverlay()
 {

--- a/src/LineBufferOverlay.h
+++ b/src/LineBufferOverlay.h
@@ -67,3 +67,4 @@ private:
 };
 
 extern LineBufferOverlay g_LineBufferOverlay;
+extern LineBufferOverlay g_barbsOnRoute_LineBufferOverlay;

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -551,9 +551,9 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
     // if not, then displays wind barbs along the calculated
     // route by looping over [last_destination_plotdata] which
     // contains lat, lon, wind info for each points.
+    std::list<PlotData> plot = GetPlotData(false);
     std::list<PlotData>::iterator it;
-    for (it = last_destination_plotdata.begin();
-         it != last_destination_plotdata.end(); it++)
+    for (it = plot.begin(); it != plot.end(); it++)
     {
         wxPoint p;
         GetCanvasPixLL(&vp, &p, it->lat, it->lon);

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -567,8 +567,8 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
         // of the arrow on the route (and not the
         // middle of the arrow) for readability.
         int xOffset, yOffset;
-        xOffset = (int)(0.5 * 30 * sin(deg2rad(W)));
-        yOffset = (int)(0.5 * 30 * cos(deg2rad(W)));
+        xOffset = (int)(0.5 * 35 * sin(deg2rad(W)));
+        yOffset = (int)(0.5 * 35 * cos(deg2rad(W)));
         
         // Draw barbs
         g_barbsOnRoute_LineBufferOverlay.pushWindArrowWithBarbs(

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -548,8 +548,6 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
     if (origin.size() < 2)
         return;
     
-    Lock();
-    
     // if not, then displays wind barbs along the calculated
     // route by looping over [last_destination_plotdata] which
     // contains lat, lon, wind info for each points.
@@ -580,9 +578,7 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
     
     // Draw the wind barbs, and use a cache
     // to avoid generating again the same wind barbs
-    Unlock();
     wind_barb_route_cache.Finalize();
-    
     wxColour colour(180, 140, 14);
     wxPoint point;
     GetCanvasPixLL(&vp, &point, configuration.StartLat, configuration.StartLon);

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -36,6 +36,7 @@
 #include "RouteMapOverlay.h"
 #include "SettingsDialog.h"
 
+
 RouteMapOverlayThread::RouteMapOverlayThread(RouteMapOverlay &routemapoverlay)
     : wxThread(wxTHREAD_JOINABLE), m_RouteMapOverlay(routemapoverlay)
 {
@@ -525,6 +526,92 @@ void RouteMapOverlay::RenderCourse(Position *pos, wxDateTime time, bool MarkAtPo
         break;
     }
     Unlock();
+}
+
+
+void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
+{
+    /* Method to render wind barbs on the route that has been generated
+     * by WeatherRouting plugin. The idead is to visualize the wind
+     * direction and strenght at any step of the trip.
+     *
+     * Customization by: Sylvain Carlioz -- with Pavel Kalian's help ;-)
+     * OpenCPN's licence
+     * March, 2018
+     */
+    
+    RouteMapConfiguration configuration = GetConfiguration();
+    
+    // if no route has been calculated by
+    // WeatherRouting, then stops the method.
+    // ([origin] is a list of all isochrons)
+    if (origin.size() < 2)
+        return;
+    
+    Lock();
+    
+    // if not, then displays wind barbs along the calculated
+    // route by looping over [last_destination_plotdata] which
+    // contains lat, lon, wind info for each points.
+    std::list<PlotData>::iterator it;
+    for (it = last_destination_plotdata.begin();
+         it != last_destination_plotdata.end(); it++)
+    {
+        wxPoint p;
+        GetCanvasPixLL(&vp, &p, it->lat, it->lon);
+        
+        double VW = it->VW;
+        double W = it->W;
+        
+        // Calculate the offset to put the head
+        // of the arrow on the route (and not the
+        // middle of the arrow) for readability.
+        int xOffset, yOffset;
+        xOffset = (int)(0.5 * 30 * sin(deg2rad(W)));
+        yOffset = (int)(0.5 * 30 * cos(deg2rad(W)));
+        
+        // Draw barbs
+        g_barbsOnRoute_LineBufferOverlay.pushWindArrowWithBarbs(
+            wind_barb_route_cache, p.x + xOffset, p.y - yOffset, VW,
+            deg2rad(W) + vp.rotation, it->lat < 0
+        );
+        
+    }
+    
+    // Draw the wind barbs, and use a cache
+    // to avoid generating again the same wind barbs
+    Unlock();
+    wind_barb_route_cache.Finalize();
+    
+    wxColour colour(180, 140, 14);
+    wxPoint point;
+    GetCanvasPixLL(&vp, &point, configuration.StartLat, configuration.StartLon);
+    
+    if(dc.GetDC())
+    {
+        dc.SetPen(wxPen(colour, 2));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    }
+#ifdef ocpnUSE_GL
+    else
+    {
+        glColor3ub(colour.Red(), colour.Green(), colour.Blue());
+        glEnable(GL_BLEND);
+        glLineWidth(2);
+        glEnableClientState(GL_VERTEX_ARRAY);
+    }
+#endif
+    
+    if(dc.GetDC()) {
+        wind_barb_route_cache.draw(dc.GetDC());
+    } else
+        wind_barb_route_cache.draw(NULL);
+    
+#ifdef ocpnUSE_GL
+    if(!dc.GetDC()) {
+        glDisableClientState(GL_VERTEX_ARRAY);
+    }
+#endif
 }
 
 void RouteMapOverlay::RenderWindBarbs(wrDC &dc, PlugIn_ViewPort &vp)

--- a/src/RouteMapOverlay.h
+++ b/src/RouteMapOverlay.h
@@ -60,7 +60,11 @@ public:
                 wrDC &dc, PlugIn_ViewPort &vp, bool justendroute);
     void RenderCourse(Position *pos, wxDateTime time, bool MarkAtPolarChange,
                       wrDC &dc, PlugIn_ViewPort &vp);
+    
+    // Customization WindBarbsOnRoute
+    void RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp);
     void RenderWindBarbs(wrDC &dc, PlugIn_ViewPort &vp);
+
     void RenderCurrent(wrDC &dc, PlugIn_ViewPort &vp);
 
     void GetLLBounds(double &latmin, double &latmax, double &lonmin, double &lonmax);
@@ -115,6 +119,9 @@ private:
     std::list<PlotData> last_destination_plotdata, last_cursor_plotdata;
 
     LineBuffer wind_barb_cache;
+    // Customization WindBarbsOnRoute
+    LineBuffer wind_barb_route_cache;
+    
     double wind_barb_cache_scale;
     size_t wind_barb_cache_origin_size;
     int wind_barb_cache_projection;

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -92,6 +92,12 @@ void SettingsDialog::LoadSettings()
     bool DisplayWindBarbs = m_cbDisplayWindBarbs->GetValue();
     pConf->Read( _T("DisplayWindBarbs"), &DisplayWindBarbs, DisplayWindBarbs);
     m_cbDisplayWindBarbs->SetValue(DisplayWindBarbs);
+    
+    // WindBarbsOnRoute Customization
+    bool DisplayWindBarbsOnRoute = m_cbDisplayWindBarbsOnRoute->GetValue();
+    pConf->Read( _T("DisplayWindBarbsOnRoute"), &DisplayWindBarbsOnRoute,
+                DisplayWindBarbsOnRoute);
+    m_cbDisplayWindBarbsOnRoute->SetValue(DisplayWindBarbsOnRoute);
 
     bool DisplayCurrent = m_cbDisplayCurrent->GetValue();
     pConf->Read( _T("DisplayCurrent"), &DisplayCurrent, DisplayCurrent);
@@ -138,6 +144,8 @@ void SettingsDialog::SaveSettings( )
     pConf->Write( _T("AlternatesForAll"), m_cbAlternatesForAll->GetValue());
     pConf->Write( _T("MarkAtPolarChange"), m_cbMarkAtPolarChange->GetValue());
     pConf->Write( _T("DisplayWindBarbs"), m_cbDisplayWindBarbs->GetValue());
+    // WindBarbsOnRoute Customization
+    pConf->Write( _T("DisplayWindBarbsOnRoute"), m_cbDisplayWindBarbsOnRoute->GetValue());
     pConf->Write( _T("DisplayCurrent"), m_cbDisplayCurrent->GetValue());
 
     pConf->Write( _T("ConcurrentThreads"), m_sConcurrentThreads->GetValue());

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -371,7 +371,9 @@ void WeatherRouting::Render(wrDC &dc, PlugIn_ViewPort &vp)
         (*it)->Render(time, m_SettingsDialog, dc, vp, false);
         
         // Start WindBarbsOnRoute customization
-        (*it)->RenderWindBarbsOnRoute(dc, vp);
+        if (it == currentroutemaps.begin() &&
+            m_SettingsDialog.m_cbDisplayWindBarbsOnRoute->GetValue())
+             (*it)->RenderWindBarbsOnRoute(dc, vp);
 
         if(it == currentroutemaps.begin() &&
            m_SettingsDialog.m_cbDisplayWindBarbs->GetValue())

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -369,6 +369,9 @@ void WeatherRouting::Render(wrDC &dc, PlugIn_ViewPort &vp)
     for(std::list<RouteMapOverlay*>::iterator it = currentroutemaps.begin();
         it != currentroutemaps.end(); it++) {
         (*it)->Render(time, m_SettingsDialog, dc, vp, false);
+        
+        // Start WindBarbsOnRoute customization
+        (*it)->RenderWindBarbsOnRoute(dc, vp);
 
         if(it == currentroutemaps.begin() &&
            m_SettingsDialog.m_cbDisplayWindBarbs->GetValue())

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -404,6 +404,10 @@ SettingsDialogBase::SettingsDialogBase( wxWindow* parent, wxWindowID id, const w
 	
 	m_cbDisplayWindBarbs = new wxCheckBox( sbSizer25->GetStaticBox(), wxID_ANY, _("Display Wind Barbs"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer82->Add( m_cbDisplayWindBarbs, 0, wxALL, 5 );
+    
+    // WindBarbsOnRoute Customization
+    m_cbDisplayWindBarbsOnRoute = new wxCheckBox(sbSizer25->GetStaticBox(), wxID_ANY, _("Display Wind Barbs On Route"), wxDefaultPosition, wxDefaultSize, 0);
+    fgSizer82->Add(m_cbDisplayWindBarbsOnRoute, 0, wxALL, 5);
 	
 	m_cbDisplayCurrent = new wxCheckBox( sbSizer25->GetStaticBox(), wxID_ANY, _("Display current"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_cbDisplayCurrent->SetValue(true); 
@@ -484,6 +488,8 @@ SettingsDialogBase::SettingsDialogBase( wxWindow* parent, wxWindowID id, const w
 	m_cbAlternatesForAll->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbMarkAtPolarChange->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayWindBarbs->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
+    // WindBarbsOnRoute Customization
+    m_cbDisplayWindBarbsOnRoute->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(SettingsDialogBase::OnUpdate), NULL, this);
 	m_cbDisplayCurrent->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cblFields->Connect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );
 	m_cbUseLocalTime->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );
@@ -501,6 +507,8 @@ SettingsDialogBase::~SettingsDialogBase()
 	m_cbAlternatesForAll->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbMarkAtPolarChange->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayWindBarbs->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
+    // WindBarbsOnRoute Customization
+    m_cbDisplayWindBarbsOnRoute->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayCurrent->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cblFields->Disconnect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );
 	m_cbUseLocalTime->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );

--- a/src/WeatherRoutingUI.h
+++ b/src/WeatherRoutingUI.h
@@ -193,6 +193,8 @@ class SettingsDialogBase : public wxDialog
 		wxCheckBox* m_cbAlternatesForAll;
 		wxCheckBox* m_cbMarkAtPolarChange;
 		wxCheckBox* m_cbDisplayWindBarbs;
+        // WindBarbsOnRoute Customization
+        wxCheckBox* m_cbDisplayWindBarbsOnRoute;
 		wxCheckBox* m_cbDisplayCurrent;
 		wxSpinCtrl* m_sConcurrentThreads;
 		wxCheckListBox* m_cblFields;


### PR DESCRIPTION
Add wind barbs along the route calculated by weather_routing.
The idea is to have a much better visualization of the wind direction and strength that we will get during the trip as grib visualizer only shows wind indication at a unique time point.

<img width="884" alt="capture d ecran 2018-03-10 a 18 40 01" src="https://user-images.githubusercontent.com/22415254/37245031-85da63aa-2492-11e8-840f-da11d2373058.png">

This option is selectable in Weather_Routing > View > Settings > Display Wind Barbs on Route.

<img width="681" alt="capture d ecran 2018-03-10 a 18 38 49" src="https://user-images.githubusercontent.com/22415254/37245017-4cd9e616-2492-11e8-965e-3629e96e0386.png">