### PR TITLE
FIX error with cache for wind barbs on route

### DIFF
--- a/src/RouteMapOverlay.h
+++ b/src/RouteMapOverlay.h
@@ -130,9 +130,6 @@ private:
     
     // Customization WindBarbsOnRoute
     LineBuffer wind_barb_route_cache;
-    double wind_barb_route_cache_scale;
-    size_t wind_barb_route_cache_origin_size;
-    int wind_barb_route_cache_projection;
 
     LineBuffer current_cache;
     double current_cache_scale;


### PR DESCRIPTION
I think caching wind barbs on route creates more problems than it solves
in saving few CPU. With boat polar change or minor time modification,
route was updated but not the related wind barbs...