### PR TITLE
Cursor on plot

### DIFF
--- a/WeatherRouting.fbp
+++ b/WeatherRouting.fbp
@@ -27,7 +27,7 @@
         <property name="ui_table">UI</property>
         <property name="use_enum">0</property>
         <property name="use_microsoft_bom">0</property>
-        <object class="Frame" expanded="0">
+        <object class="Frame" expanded="1">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -10779,7 +10779,7 @@
                         <property name="maximum_size"></property>
                         <property name="min_size"></property>
                         <property name="minimize_button">0</property>
-                        <property name="minimum_size"></property>
+                        <property name="minimum_size">-1,210</property>
                         <property name="moveable">1</property>
                         <property name="name">m_PlotWindow</property>
                         <property name="pane_border">1</property>
@@ -10821,7 +10821,7 @@
                         <event name="OnRightUp"></event>
                         <event name="OnSetFocus"></event>
                         <event name="OnSize">OnSizePlot</event>
-                        <event name="OnUpdateUI"></event>
+                        <event name="OnUpdateUI">OnUpdateUI</event>
                     </object>
                 </object>
                 <object class="sizeritem" expanded="0">
@@ -11489,7 +11489,7 @@
                                                         <property name="maximum_size"></property>
                                                         <property name="min_size"></property>
                                                         <property name="minimize_button">0</property>
-                                                        <property name="minimum_size"></property>
+                                                        <property name="minimum_size">130,-1</property>
                                                         <property name="moveable">1</property>
                                                         <property name="name">m_stMousePosition1</property>
                                                         <property name="pane_border">1</property>
@@ -22915,11 +22915,11 @@
                                 <event name="OnUpdateUI"></event>
                             </object>
                         </object>
-                        <object class="sizeritem" expanded="1">
+                        <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
                             <property name="flag">wxALL|wxEXPAND</property>
                             <property name="proportion">0</property>
-                            <object class="wxStaticText" expanded="1">
+                            <object class="wxStaticText" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>

--- a/src/PlotDialog.cpp
+++ b/src/PlotDialog.cpp
@@ -240,14 +240,16 @@ void PlotDialog::OnPaintPlot(wxPaintEvent& event)
     // the current time position by the GRIB file
     wxDateTime gribTime = m_WeatherRouting.m_ConfigurationDialog.m_GribTimelineTime;
     double cursorTime = (gribTime - m_StartTime).GetSeconds().ToDouble();
-    int x_cursor = w * (scale * ((cursorTime - m_mintime) / (m_maxtime - m_mintime) - \
-                                 position) + position);
-    
-    wxColor orange(255, 165, 0);
-    wxPen cursorPen(orange, 3, wxPENSTYLE_DOT);
-    dc.SetPen(cursorPen);
-    dc.DrawLine(x_cursor, 0, x_cursor, h);
-    
+    if (cursorTime <= m_maxtime || cursorTime >= m_mintime)
+    {
+        int x_cursor = w * (scale * ((cursorTime - m_mintime) / (m_maxtime - m_mintime) - \
+                                     position) + position);
+        
+        wxColor orange(255, 165, 0);
+        wxPen cursorPen(orange, 3, wxPENSTYLE_DOT);
+        dc.SetPen(cursorPen);
+        dc.DrawLine(x_cursor, 0, x_cursor, h);
+    }
     // ----------------------------------------------------------------
 
     dc.SetTextForeground(*wxBLACK);

--- a/src/PlotDialog.cpp
+++ b/src/PlotDialog.cpp
@@ -50,6 +50,7 @@ PlotDialog::PlotDialog( WeatherRouting &weatherrouting )
 #endif
       m_WeatherRouting(weatherrouting)
 {
+    
 }
 
 PlotDialog::~PlotDialog()
@@ -232,10 +233,26 @@ void PlotDialog::OnPaintPlot(wxPaintEvent& event)
             lx = x, ly = y;
         }
     }
+    
+    // Cursor Customization
+    // ----------------------------------------------------------------
+    // Draw a cursor on the graph to show
+    // the current time position by the GRIB file
+    wxDateTime gribTime = m_WeatherRouting.m_ConfigurationDialog.m_GribTimelineTime;
+    double cursorTime = (gribTime - m_StartTime).GetSeconds().ToDouble();
+    int x_cursor = w * (scale * ((cursorTime - m_mintime) / (m_maxtime - m_mintime) - \
+                                 position) + position);
+    
+    wxColor orange(255, 165, 0);
+    wxPen cursorPen(orange, 3, wxPENSTYLE_DOT);
+    dc.SetPen(cursorPen);
+    dc.DrawLine(x_cursor, 0, x_cursor, h);
+    
+    // ----------------------------------------------------------------
 
     dc.SetTextForeground(*wxBLACK);
     dc.SetPen(wxPen(*wxBLACK, 1, wxPENSTYLE_DOT));
-
+    
     const double steps = 10;
     bool grid = true;
     for(double i=1/steps; i<1-1/steps; i+=1/steps) {
@@ -282,4 +299,9 @@ void PlotDialog::SetRouteMapOverlay(RouteMapOverlay *routemapoverlay)
         m_PlotData = routemapoverlay->GetPlotData(m_rbCursorRoute->GetValue());
     GetScale();
     m_PlotWindow->Refresh();
+}
+
+void PlotDialog::OnUpdateUI(wxUpdateUIEvent &event)
+{
+    SetRouteMapOverlay(m_WeatherRouting.FirstCurrentRouteMap());
 }

--- a/src/PlotDialog.h
+++ b/src/PlotDialog.h
@@ -57,6 +57,7 @@ private:
     void OnUpdatePlot( wxScrollEvent& event ) { m_PlotWindow->Refresh(); }
     void OnUpdatePlotVariable( wxCommandEvent& event ) { GetScale(); m_PlotWindow->Refresh(); }
     void OnUpdateRoute( wxCommandEvent& event );
+    void OnUpdateUI( wxUpdateUIEvent& event );
 
 private:
 
@@ -72,6 +73,7 @@ private:
     std::list<PlotData> m_PlotData;
 
     WeatherRouting &m_WeatherRouting;
+
 };
 
 #endif

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1362,6 +1362,8 @@ PlotDialogBase::PlotDialogBase( wxWindow* parent, wxWindowID id, const wxString&
 	
 	m_PlotWindow = new wxScrolledWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL|wxVSCROLL );
 	m_PlotWindow->SetScrollRate( 5, 5 );
+	m_PlotWindow->SetMinSize( wxSize( -1,210 ) );
+	
 	fgSizer3->Add( m_PlotWindow, 1, wxEXPAND | wxALL, 5 );
 	
 	wxFlexGridSizer* fgSizer12;
@@ -1418,6 +1420,7 @@ PlotDialogBase::PlotDialogBase( wxWindow* parent, wxWindowID id, const wxString&
 	m_stMousePosition1 = new wxStaticText( this, wxID_ANY, _("        N/A         "), wxDefaultPosition, wxDefaultSize, 0 );
 	m_stMousePosition1->Wrap( -1 );
 	m_stMousePosition1->SetForegroundColour( wxColour( 251, 2, 7 ) );
+	m_stMousePosition1->SetMinSize( wxSize( 130,-1 ) );
 	
 	fgSizer78->Add( m_stMousePosition1, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	
@@ -1513,6 +1516,7 @@ PlotDialogBase::PlotDialogBase( wxWindow* parent, wxWindowID id, const wxString&
 	m_PlotWindow->Connect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( PlotDialogBase::OnMouseEventsPlot ), NULL, this );
 	m_PlotWindow->Connect( wxEVT_PAINT, wxPaintEventHandler( PlotDialogBase::OnPaintPlot ), NULL, this );
 	m_PlotWindow->Connect( wxEVT_SIZE, wxSizeEventHandler( PlotDialogBase::OnSizePlot ), NULL, this );
+	m_PlotWindow->Connect( wxEVT_UPDATE_UI, wxUpdateUIEventHandler( PlotDialogBase::OnUpdateUI ), NULL, this );
 	m_sPosition->Connect( wxEVT_SCROLL_TOP, wxScrollEventHandler( PlotDialogBase::OnUpdatePlot ), NULL, this );
 	m_sPosition->Connect( wxEVT_SCROLL_BOTTOM, wxScrollEventHandler( PlotDialogBase::OnUpdatePlot ), NULL, this );
 	m_sPosition->Connect( wxEVT_SCROLL_LINEUP, wxScrollEventHandler( PlotDialogBase::OnUpdatePlot ), NULL, this );
@@ -1555,6 +1559,7 @@ PlotDialogBase::~PlotDialogBase()
 	m_PlotWindow->Disconnect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( PlotDialogBase::OnMouseEventsPlot ), NULL, this );
 	m_PlotWindow->Disconnect( wxEVT_PAINT, wxPaintEventHandler( PlotDialogBase::OnPaintPlot ), NULL, this );
 	m_PlotWindow->Disconnect( wxEVT_SIZE, wxSizeEventHandler( PlotDialogBase::OnSizePlot ), NULL, this );
+	m_PlotWindow->Disconnect( wxEVT_UPDATE_UI, wxUpdateUIEventHandler( PlotDialogBase::OnUpdateUI ), NULL, this );
 	m_sPosition->Disconnect( wxEVT_SCROLL_TOP, wxScrollEventHandler( PlotDialogBase::OnUpdatePlot ), NULL, this );
 	m_sPosition->Disconnect( wxEVT_SCROLL_BOTTOM, wxScrollEventHandler( PlotDialogBase::OnUpdatePlot ), NULL, this );
 	m_sPosition->Disconnect( wxEVT_SCROLL_LINEUP, wxScrollEventHandler( PlotDialogBase::OnUpdatePlot ), NULL, this );

--- a/src/WeatherRoutingUI.h
+++ b/src/WeatherRoutingUI.h
@@ -342,6 +342,7 @@ class PlotDialogBase : public wxDialog
 		virtual void OnMouseEventsPlot( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnPaintPlot( wxPaintEvent& event ) { event.Skip(); }
 		virtual void OnSizePlot( wxSizeEvent& event ) { event.Skip(); }
+		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnUpdatePlot( wxScrollEvent& event ) { event.Skip(); }
 		virtual void OnUpdatePlotVariable( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnUpdateRoute( wxCommandEvent& event ) { event.Skip(); }


### PR DESCRIPTION
Add a cursor on the plot to display where we are on time (selected from grib_pi).
As @seandepagnier suggests maybe this plot should be improve to have a better scale, readability, options, etc. 

<img width="795" alt="capture d ecran 2018-03-18 a 01 27 22" src="https://user-images.githubusercontent.com/22415254/37561307-8dd44580-2a4b-11e8-8a14-41a5ed57fbb1.png">
