### PR TITLE
Fix crash when editing polars caused by spurious paint events.

### DIFF
--- a/src/BoatDialog.cpp
+++ b/src/BoatDialog.cpp
@@ -58,7 +58,7 @@ BoatDialog::BoatDialog(WeatherRouting &weatherrouting)
 #else
     : BoatDialogBase(&weatherrouting, wxID_ANY, _("Boat"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxSTAY_ON_TOP ),
 #endif
-      m_WeatherRouting(weatherrouting), m_PlotScale(0), m_CrossOverRegenerate(false), m_CrossOverGenerationThread(NULL)
+      m_WeatherRouting(weatherrouting), m_PlotScale(0), m_CrossOverRegenerate(false), m_CrossOverGenerationThread(NULL), m_EditingPolar(false)
 {
     // for small screens: don't let boat dialog be larger than screen
     int w,h;
@@ -209,6 +209,9 @@ void BoatDialog::OnMouseEventsPolarPlot( wxMouseEvent& event )
 
 void BoatDialog::OnPaintPlot(wxPaintEvent& event)
 {
+    if (m_EditingPolar)
+        return;
+
     wxWindow *window = dynamic_cast<wxWindow*>(event.GetEventObject());
     if(!window)
         return;
@@ -495,6 +498,9 @@ static int CalcPolarPoints(wxPoint p0, wxPoint p1)
 
 void BoatDialog::OnPaintCrossOverChart(wxPaintEvent& event)
 {
+    if (m_EditingPolar)
+        return;
+
     wxWindow *window = dynamic_cast<wxWindow*>(event.GetEventObject());
     if(!window)
         return;
@@ -815,6 +821,8 @@ void BoatDialog::OnEditPolar( wxCommandEvent& event )
     if(i == -1)
         return;
 
+    m_EditingPolar = true;
+
     EditPolarDialog dlg(this);
          
     dlg.SetPolarIndex(i);
@@ -831,6 +839,8 @@ void BoatDialog::OnEditPolar( wxCommandEvent& event )
                          + message, _("OpenCPN Weather Routing Plugin"),
                          wxICON_ERROR | wxOK );
     }
+
+    m_EditingPolar = false;
 
     GenerateCrossOverChart();
     RefreshPlots();

--- a/src/BoatDialog.h
+++ b/src/BoatDialog.h
@@ -90,6 +90,8 @@ private:
 
     bool m_CrossOverRegenerate;
     CrossOverGenerationThread *m_CrossOverGenerationThread;
+
+    bool m_EditingPolar;
 };
 
 #endif


### PR DESCRIPTION
For some reason, some spurious paint events are generated by the BoatDialog
at the same time the user tries to edit or modify the polar. The code in the
paint event handler accesses the polar data in an unprotected way, and reads
uninitialized data at some point.

This commit fixes this issue by blocking the paint event handlers while the
EditPolarDialog is shown.

This should hopefully fix issue #170 .