### PR TITLE
Fix example configurations and polars

### DIFF
--- a/data/boats/Boat-Climatology.xml
+++ b/data/boats/Boat-Climatology.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <OpenCPNWeatherRoutingBoat version="1.10" creator="Opencpn Weather Routing plugin">
-    <Polar FileName="TWS-0-6.pol" CrossOverPercentage="0" />
-    <Polar FileName="TWS-6-20.pol" CrossOverPercentage="0" />
-    <Polar FileName="TWS-20-60.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-0-10.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-06-24.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-15-30.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-24-60.pol" CrossOverPercentage="0" />
 </OpenCPNWeatherRoutingBoat>

--- a/data/boats/Boat-Test-Power.xml
+++ b/data/boats/Boat-Test-Power.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <OpenCPNWeatherRoutingBoat version="1.10" creator="Opencpn Weather Routing plugin">
-    <Polar FileName="TWS-0-6-Power.pol" CrossOverPercentage="0" />
-    <Polar FileName="TWS-6-20.pol" CrossOverPercentage="0" />
-    <Polar FileName="TWS-20-60.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-0-6-Power.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-06-24.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-15-30.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-24-60.pol" CrossOverPercentage="0" />
 </OpenCPNWeatherRoutingBoat>

--- a/data/boats/Boat-Test.xml
+++ b/data/boats/Boat-Test.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <OpenCPNWeatherRoutingBoat version="1.10" creator="Opencpn Weather Routing plugin">
-    <Polar FileName="TWS-0-6.pol" CrossOverPercentage="0" />
-    <Polar FileName="TWS-6-20.pol" CrossOverPercentage="0" />
-    <Polar FileName="TWS-20-60.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-0-10.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-06-24.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-15-30.pol" CrossOverPercentage="0" />
+    <Polar FileName="Example/Example-24-60.pol" CrossOverPercentage="0" />
 </OpenCPNWeatherRoutingBoat>

--- a/src/Boat.cpp
+++ b/src/Boat.cpp
@@ -75,6 +75,7 @@ wxString Boat::OpenXML(wxString filename, bool shortcut)
             Polar polar; //(wxString::FromUTF8(e->Attribute("Name")));
 
             polar.FileName = wxString::FromUTF8(e->Attribute("FileName"));
+            polar.FileName.Replace (_T("/"), wxFileName::GetPathSeparator());
             if(!wxFileName::FileExists(polar.FileName))
 	        polar.FileName = weather_routing_pi::StandardPath() + _T("polars") +
 		                 wxFileName::GetPathSeparator() + polar.FileName;

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -154,7 +154,7 @@ WeatherRouting::WeatherRouting(wxWindow *parent, weather_routing_pi &plugin)
 
     /* ensure the directories exist */
     wxFileName fn;
-    fn.Mkdir(weather_routing_pi::StandardPath());
+    fn.Mkdir(weather_routing_pi::StandardPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
     fn.Mkdir(boatsdir);
     fn.Mkdir(polarsdir);
 
@@ -333,11 +333,23 @@ WeatherRouting::~WeatherRouting( )
 
 void WeatherRouting::CopyDataFiles(wxString from, wxString to)
 {
-    wxArrayString fns;
-    wxDir::GetAllFiles(from, &fns);
-    for (unsigned int i = 0; i < fns.Count(); i++) {
-	wxFileName f(fns.Item(i));
-	wxCopyFile(fns.Item(i), to + wxFileName::GetPathSeparator() + f.GetFullName());
+    if (from[from.Len() - 1] != '\\' && from[from.Len() - 1] != '/') from += wxFILE_SEP_PATH;
+    if (to[to.Len() - 1] != '\\' && to[to.Len() - 1] != '/') to += wxFILE_SEP_PATH;
+
+    if (!wxDirExists(to))
+	wxFileName::Mkdir(to, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+    wxDir dir(from);
+    wxString next = wxEmptyString;
+    bool b = dir.GetFirst(&next);
+    while (b) {
+        const wxString fileFrom = from + next;
+        const wxString fileTo = to + next;
+        if (wxDirExists(fileFrom))
+            CopyDataFiles(fileFrom, fileTo);
+        else
+	    wxCopyFile(fileFrom, fileTo);
+        b = dir.GetNext(&next);
     }
 }
 


### PR DESCRIPTION
These got broken when the example polars were moved into the Example/
subdirectory, as the boats were not modified and the initial configuration
copy logic didn't take subdirectories into account.