### PR TITLE
properly save and restore route SafetyMarginLand

### DIFF
--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -215,6 +215,7 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
     SET_CHECKBOX(AvoidCycloneTracks);
     SET_SPIN(CycloneMonths);
     SET_SPIN(CycloneDays);
+    SET_SPIN(SafetyMarginLand);
 
     SET_CHECKBOX(DetectLand);
     SET_CHECKBOX(DetectBoundary);
@@ -265,22 +266,28 @@ void ConfigurationDialog::SetBoatFilename(wxString path)
 void ConfigurationDialog::OnResetAdvanced( wxCommandEvent& event )
 {
     m_bBlockUpdate = true;
+
+    // constraints
     m_sMaxLatitude->SetValue(90);
-    m_sTackingTime->SetValue(0);
     m_sWindVSCurrent->SetValue(0);
     m_sMaxCourseAngle->SetValue(180);
     m_sMaxSearchAngle->SetValue(120);
     m_cbAvoidCycloneTracks->SetValue(false);
+    // XXX missing 2
+
+    // Options
     m_cbInvertedRegions->SetValue(false);
     m_cbAnchoring->SetValue(false);
     m_cIntegrator->SetSelection(0);
     m_sWindStrength->SetValue(100);
     m_sTackingTime->SetValue(0);
+    m_sSafetyMarginLand->SetValue(2.);
+
     m_sFromDegree->SetValue(0);
     m_sToDegree->SetValue(180);
     m_tByDegrees->SetValue(_T("5"));
-    m_bBlockUpdate = false;
 
+    m_bBlockUpdate = false;
     Update();
 }
 

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1430,6 +1430,7 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure)
                     configuration.WindStrength = AttributeDouble(e, "WindStrength", 1);
 
                     configuration.DetectLand = AttributeBool(e, "DetectLand", true);
+                    configuration.SafetyMarginLand = AttributeDouble(e, "SafetyMarginLand", 2.);
                     configuration.DetectBoundary = AttributeBool(e, "DetectBoundary", false);
                     configuration.Currents = AttributeBool(e, "Currents", true);
                     configuration.OptimizeTacking = AttributeBool(e, "OptimizeTacking", false);
@@ -1533,6 +1534,7 @@ void WeatherRouting::SaveXML(wxString filename)
         c->SetDoubleAttribute("WindStrength", configuration.WindStrength);
 
         c->SetAttribute("DetectLand", configuration.DetectLand);
+        c->SetAttribute("SafetyMarginLand", configuration.SafetyMarginLand);
         c->SetAttribute("DetectBoundary", configuration.DetectBoundary);
         c->SetAttribute("Currents", configuration.Currents);
         c->SetAttribute("OptimizeTacking", configuration.OptimizeTacking);
@@ -2268,6 +2270,7 @@ RouteMapConfiguration WeatherRouting::DefaultConfiguration()
     configuration.AllowDataDeficient = false;
     configuration.WindStrength = 1;
     configuration.DetectLand = true;
+    configuration.SafetyMarginLand = 2.;
     configuration.DetectBoundary = false;
     configuration.Currents = false;
     configuration.OptimizeTacking = false;


### PR DESCRIPTION
Hi,
Don't use whatever was previously set for safety margin but a per configuration attribute.

I haven't fully tested it but even if does something land detection doesn't seems to be 100% reliable (I tested with climatology and margin between 2 and 10).

Maybe it'd be easier to update ghhs crossing detection to clipper ( http://www.angusj.com/delphi/clipper/documentation/Docs/_Body.htm )? It would be great if it could work with DR too, DR is already using clipper. I have a POC extracting dangers, land and depth contours from s57 charts but it's using glu which is a dead end, too slow and too many small errors, and in my understanting Sean tried to us libtess2 and found it's not good enough.

Regards
Didier