### PR TITLE
Locks

### DIFF
--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -63,8 +63,8 @@ RouteMapOverlay::RouteMapOverlay()
     : m_UpdateOverlay(true), m_bEndRouteVisible(false), m_Thread(NULL),
       last_cursor_lat(0), last_cursor_lon(0),
       last_cursor_position(NULL), destination_position(NULL), last_destination_position(NULL),
-      m_bUpdated(false), clear_destination_plotdata(false),
-      m_overlaylist(0), current_cache_origin_size(0)
+      m_bUpdated(false), m_overlaylist(0),
+      clear_destination_plotdata(false),current_cache_origin_size(0)
 {
 }
 
@@ -599,8 +599,6 @@ void RouteMapOverlay::RenderCourse(bool cursor_route, wrDC &dc, PlugIn_ViewPort 
     if(!pos)
         return;
 
-    Lock();
-
     /* ComfortDisplay Customization
      * ------------------------------------------------
      * To get weather data (wind, current, waves) on a
@@ -611,10 +609,10 @@ void RouteMapOverlay::RenderCourse(bool cursor_route, wrDC &dc, PlugIn_ViewPort 
     std::list<PlotData> plot = GetPlotData(false);
     std::list<PlotData>::reverse_iterator itt = plot.rbegin();
     if (itt == plot.rend()) {
-        Unlock();
         return;
     }
 
+    Lock();
     wxColor lc = sailingConditionColor(sailingConditionLevel(*itt));
 
     /* draw lines to this route */
@@ -651,7 +649,6 @@ void RouteMapOverlay::RenderBoatOnCourse(bool cursor_route, wxDateTime time, wrD
     if(!pos)
         return;
     
-    Lock();
     std::list<PlotData> plot = GetPlotData(cursor_route);
     
     for(std::list<PlotData>::iterator it = plot.begin(); it != plot.end(); )  {
@@ -682,7 +679,6 @@ void RouteMapOverlay::RenderBoatOnCourse(bool cursor_route, wxDateTime time, wrD
         dc.DrawCircle( r.x, r.y, 7 );
         break;
     }
-    Unlock();
 }
 
 void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -49,7 +49,8 @@ void *RouteMapOverlayThread::Entry()
         if(!m_RouteMapOverlay.Propagate())
             wxThread::Sleep(50);
         else {
-            m_RouteMapOverlay.UpdateCursorPosition();
+            // don't do it inside worker thread, race
+            // m_RouteMapOverlay.UpdateCursorPosition();
             m_RouteMapOverlay.UpdateDestination();
             wxThread::Sleep(5);
         }
@@ -62,7 +63,8 @@ RouteMapOverlay::RouteMapOverlay()
     : m_UpdateOverlay(true), m_bEndRouteVisible(false), m_Thread(NULL),
       last_cursor_lat(0), last_cursor_lon(0),
       last_cursor_position(NULL), destination_position(NULL), last_destination_position(NULL),
-      m_bUpdated(false), m_overlaylist(0), current_cache_origin_size(0)
+      m_bUpdated(false), clear_destination_plotdata(false),
+      m_overlaylist(0), current_cache_origin_size(0)
 {
 }
 
@@ -1216,6 +1218,10 @@ void RouteMapOverlay::RequestGrib(wxDateTime time)
 std::list<PlotData> &RouteMapOverlay::GetPlotData(bool cursor_route)
 {
     std::list<PlotData> &plotdata = cursor_route ? last_cursor_plotdata : last_destination_plotdata;
+    if (!cursor_route && clear_destination_plotdata ) {
+        clear_destination_plotdata  = false;
+        plotdata.clear();
+    }
     if(plotdata.empty()) {
         Position *next = cursor_route ? last_cursor_position : last_destination_position;
 
@@ -1392,6 +1398,8 @@ void RouteMapOverlay::Clear()
     RouteMap::Clear();
     last_cursor_position = NULL;
     last_destination_position = NULL;
+    clear_destination_plotdata = false;
+    // clear_cursor_plotdata = false;
     last_cursor_plotdata.clear();
     last_destination_plotdata.clear();
     m_UpdateOverlay = true;
@@ -1399,6 +1407,7 @@ void RouteMapOverlay::Clear()
 
 void RouteMapOverlay::UpdateCursorPosition()
 {
+    // only called in main thread, no race
     Position *last_last_cursor_position = last_cursor_position;
     last_cursor_position = ClosestPosition(last_cursor_lat, last_cursor_lon, &m_cursor_time);
     if(last_last_cursor_position != last_cursor_position)
@@ -1428,9 +1437,9 @@ void RouteMapOverlay::UpdateDestination()
     Position *last_last_destination_position = last_destination_position;
     bool done = ReachedDestination();
     if(done) {
+        Lock();
         delete destination_position;
         destination_position = 0;
-        Lock();
         /* this doesn't happen often, so can be slow.. for each position in the last
            isochron, we try to propagate to the destination */
         IsoChronList::iterator iit = origin.end();
@@ -1469,8 +1478,11 @@ void RouteMapOverlay::UpdateDestination()
         m_EndTime = wxDateTime(); // invalid
     }
 
-    if(last_last_destination_position != last_destination_position)
-        last_destination_plotdata.clear();
+    if(last_last_destination_position != last_destination_position) {
+        // we can't clear because we are inside a worker thread
+        // and there's a race with GetPlotData
+        clear_destination_plotdata = true;
+    }
 
     m_bUpdated = true;
     m_UpdateOverlay = true;

--- a/src/RouteMapOverlay.h
+++ b/src/RouteMapOverlay.h
@@ -121,7 +121,10 @@ private:
 
     int m_overlaylist, m_overlaylist_projection;
 
-    std::list<PlotData> last_destination_plotdata, last_cursor_plotdata;
+    bool clear_destination_plotdata; // should be volatile
+    std::list<PlotData> last_destination_plotdata;
+
+    std::list<PlotData> last_cursor_plotdata;
 
     LineBuffer wind_barb_cache;
     double wind_barb_cache_scale;


### PR DESCRIPTION
Hi,
Using plotdata in route rendering triggers a race. List is cleared in a worker thread but it's read in the main one, could be one of the reasons for recent crashes reports.

so:
- don't update cursor position in worker threads, it's done in the main thread, worst case: displaying slightly out of date data.

- don't clear last position plot list in worker threads, only set a request to do it for  getplotdata. 
I can't stand the BS of protecting a single assignment with a mutex, it's very unlikely compiler would optimize it out anyway and it'd be solved in c++11.

- remove some Lock recursive calls, by default wxMutex aren't recursive.

Regards
Didier