### PR TITLE
Add GUID to route and position.

### DIFF
--- a/src/RouteMap.h
+++ b/src/RouteMap.h
@@ -279,10 +279,11 @@ public:
 typedef std::list<IsoChron*> IsoChronList;
 
 struct RouteMapPosition {
-    RouteMapPosition(wxString n, double lat0, double lon0)
-    : Name(n), lat(lat0), lon(lon0) {}
+    RouteMapPosition(wxString n, double lat0, double lon0, wxString guid = wxEmptyString)
+    : Name(n), GUID(guid), lat(lat0), lon(lon0) {}
 
     wxString Name;
+    wxString GUID;
     double lat, lon;
 };
 
@@ -290,6 +291,7 @@ struct RouteMapConfiguration {
     RouteMapConfiguration () : StartLon(0), EndLon(0), grib_is_data_deficient(false) {} /* avoid waiting forever in update longitudes */
     bool Update();
 
+    wxString RouteGUID;       /* Route GUID if any */
     wxString Start, End;
     wxDateTime StartTime;
 

--- a/src/WeatherRouting.h
+++ b/src/WeatherRouting.h
@@ -109,7 +109,7 @@ public:
     void UpdateDisplaySettings();
 
     void AddPosition(double lat, double lon);
-    void AddPosition(double lat, double lon, wxString name);
+    void AddPosition(double lat, double lon, wxString name, wxString GUID = wxEmptyString);
 
     void CursorRouteChanged();
     void UpdateColumns();


### PR DESCRIPTION
Hi,
I'm trying to add the capability to use OopenCPN waypoints and routes in weather routing, for that I have to keep around O GUID, but every time I go back to WR master branch these GUID are removed from XML file and it's a pain.

With this batch if there's a GUID in XML it's saved back, it there's none it doesn't add none.

Regards
Didier

