### PR TITLE
FIX default safety margin to 0NM (instead of 2NM)

### DIFF
--- a/WeatherRouting.fbp
+++ b/WeatherRouting.fbp
@@ -10066,7 +10066,7 @@
                                                                             <property name="gripper">0</property>
                                                                             <property name="hidden">0</property>
                                                                             <property name="id">wxID_ANY</property>
-                                                                            <property name="initial">2</property>
+                                                                            <property name="initial">0</property>
                                                                             <property name="max">100</property>
                                                                             <property name="max_size"></property>
                                                                             <property name="maximize_button">0</property>

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1051,7 +1051,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_staticText241->Wrap( -1 );
 	fgSizer11511->Add( m_staticText241, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	
-	m_sSafetyMarginLand = new wxSpinCtrl( sbSizer29->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 60,-1 ), wxSP_ARROW_KEYS, 0, 100, 2 );
+	m_sSafetyMarginLand = new wxSpinCtrl( sbSizer29->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 60,-1 ), wxSP_ARROW_KEYS, 0, 100, 0 );
 	fgSizer11511->Add( m_sSafetyMarginLand, 0, wxALL, 5 );
 	
 	m_staticText1211 = new wxStaticText( sbSizer29->GetStaticBox(), wxID_ANY, _("NM"), wxDefaultPosition, wxDefaultSize, 0 );


### PR DESCRIPTION
I suggest that safety margin from land was set to zero by default as sometimes (close to land) weather route is not able to find any route...
What do you think?