### PR TITLE
FIX wind bars on route always visible if visible click

### DIFF
--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -375,6 +375,10 @@ void WeatherRouting::Render(wrDC &dc, PlugIn_ViewPort &vp)
             reinterpret_cast<WeatherRoute*>(wxUIntToPtr(m_panel->m_lWeatherRoutes->GetItemData(i)));
         if(weatherroute->routemapoverlay->m_bEndRouteVisible)
             weatherroute->routemapoverlay->Render(time, m_SettingsDialog, dc, vp, true);
+        
+        // Start WindBarbsOnRoute customization
+        if (m_SettingsDialog.m_cbDisplayWindBarbsOnRoute->GetValue())
+            weatherroute->routemapoverlay->RenderWindBarbsOnRoute(dc, vp);
     }
 
     std::list<RouteMapOverlay *>currentroutemaps = CurrentRouteMaps();
@@ -382,11 +386,6 @@ void WeatherRouting::Render(wrDC &dc, PlugIn_ViewPort &vp)
         it != currentroutemaps.end(); it++) {
         (*it)->Render(time, m_SettingsDialog, dc, vp, false);
         
-        // Start WindBarbsOnRoute customization
-        if (it == currentroutemaps.begin() &&
-            m_SettingsDialog.m_cbDisplayWindBarbsOnRoute->GetValue())
-             (*it)->RenderWindBarbsOnRoute(dc, vp);
-
         if(it == currentroutemaps.begin() &&
            m_SettingsDialog.m_cbDisplayWindBarbs->GetValue())
             (*it)->RenderWindBarbs(dc, vp);


### PR DESCRIPTION
I propose to keep the wind barbs on route visible when route is selected or not.
Before, when you deselect the route, wind barbs disappear.
