### PR TITLE
cleanup RenderWindBarbsOnRoute

### DIFF
--- a/src/LineBufferOverlay.cpp
+++ b/src/LineBufferOverlay.cpp
@@ -49,7 +49,7 @@ void LineBuffer::Finalize()
     buffer.clear();
 }
 
-void LineBuffer::pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south)
+void LineBuffer::pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south, bool head)
 {
     // transform vertexes by angle
     float sa = sinf( ang ), ca = cosf( ang );
@@ -57,12 +57,21 @@ void LineBuffer::pushTransformedBuffer(LineBuffer &buffer, int x, int y, double 
     float m[2][2] = {{ ca, -sa},
                      { sa,  ca}};
 
-    if(south)
-        m[0][0] = -m[0][0], m[1][0] = -m[1][0];
+    if(south) {
+        m[0][0] = -m[0][0];
+        m[1][0] = -m[1][0];
+    }
+    if(head) {
+        // Calculate the offset to put the head
+        // of the arrow on the point (and not the
+        // middle of the arrow).
+        x += (int)(0.5 * 35 * sa);
+        y -= (int)(0.5 * 35 * ca);
+    }
 
     for(int i=0; i < 2*buffer.count; i+=2) {
         float *k = buffer.lines + 2*i;
-        pushLine(k[0]*m[0][0] + k[1]*m[0][1] + x, k[0]*m[1][0] + k[1]*m[1][1] + y,
+        pushLine(k[0]*m[0][0] + k[1]*m[0][1] + x , k[0]*m[1][0] + k[1]*m[1][1] + y,
                  k[2]*m[0][0] + k[3]*m[0][1] + x, k[2]*m[1][0] + k[3]*m[1][1] + y);
     }
 }
@@ -203,7 +212,7 @@ LineBufferOverlay::LineBufferOverlay()
 
 }
 
-void LineBufferOverlay::pushWindArrowWithBarbs(LineBuffer &buffer, int x, int y, double vkn, double ang, bool south)
+void LineBufferOverlay::pushWindArrowWithBarbs(LineBuffer &buffer, int x, int y, double vkn, double ang, bool south, bool head)
 {
     int cacheidx;
 
@@ -219,7 +228,7 @@ void LineBufferOverlay::pushWindArrowWithBarbs(LineBuffer &buffer, int x, int y,
         cacheidx = 13;
     else 
         return;
-    buffer.pushTransformedBuffer(m_WindArrowCache[cacheidx], x, y, ang, south);
+    buffer.pushTransformedBuffer(m_WindArrowCache[cacheidx], x, y, ang, south, head);
 }
 
 void LineBufferOverlay::pushSingleArrow( LineBuffer &buffer, int x, int y, double vkn, double ang, bool south)

--- a/src/LineBufferOverlay.h
+++ b/src/LineBufferOverlay.h
@@ -35,7 +35,7 @@ public:
     void pushLine( float x0, float y0, float x1, float y1 );
     void Finalize();
 
-    void pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south=false);
+    void pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south=false, bool head=false);
     void draw(wxDC *dc);
     void drawTransformed(wxDC *dc, wxPoint offset, double ang);
 
@@ -58,7 +58,7 @@ class LineBufferOverlay
 {
 public:
     LineBufferOverlay();
-    void pushWindArrowWithBarbs(LineBuffer &buffer, int x, int y, double vkn, double ang, bool south=false);
+    void pushWindArrowWithBarbs(LineBuffer &buffer, int x, int y, double vkn, double ang, bool south=false, bool head=false);
     void pushSingleArrow( LineBuffer &buffer, int x, int y, double vkn, double ang, bool south=false);
 private:
 

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -694,19 +694,14 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
      * OpenCPN's licence
      * March, 2018
      */
-    
+    if (vp.bValid == false)
+        return;
+
     RouteMapConfiguration configuration = GetConfiguration();
-    
-    
+
     // Create a specific viewport at position (0,0)
     // to draw the winds barbs, and then translate it
     PlugIn_ViewPort nvp = vp;
-    nvp.clat = configuration.StartLat, nvp.clon = configuration.StartLon;
-    nvp.pix_width = 0;
-    nvp.pix_height = 0;
-    nvp.rotation = 0;
-    nvp.skew = 0;
-    
     // calculate wind barbs along the route by looping
     // over [GetPlotData(false)] list which contains lat,
     // lon, wind info for each points, only if needed.
@@ -725,17 +720,10 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
         double VW = it->VW;
         double W = it->W;
         
-        // Calculate the offset to put the head
-        // of the arrow on the route (and not the
-        // middle of the arrow) for readability.
-        int xOffset, yOffset;
-        xOffset = (int)(0.5 * 35 * sin(deg2rad(W)));
-        yOffset = (int)(0.5 * 35 * cos(deg2rad(W)));
-        
         // Draw barbs
         g_barbsOnRoute_LineBufferOverlay.pushWindArrowWithBarbs(
-            wind_barb_route_cache, p.x + xOffset, p.y - yOffset, VW,
-            deg2rad(W) + nvp.rotation, it->lat < 0
+            wind_barb_route_cache, p.x, p.y, VW,
+            deg2rad(W) + nvp.rotation, it->lat < 0, true
         );
     }
     wind_barb_route_cache.Finalize();
@@ -753,12 +741,6 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
 #ifdef ocpnUSE_GL
     else
     {
-        // Translate and rotate the matrix
-        // anyway, event if cached
-        glPushMatrix();
-        glTranslated(point.x, point.y, 0);
-        glRotated(vp.rotation*180/M_PI, 0, 0, 1);
-        
         // Anti-aliasing options to render
         // wind barbs at best quality (copy from grip_pi)
         glEnable(GL_BLEND);
@@ -772,15 +754,7 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
     }
 #endif
     
-    if(dc.GetDC()) {
-        // Draw the wind barbs with a correction
-        // in all cases on position and rotation
-        LineBuffer tb;
-        tb.pushTransformedBuffer(wind_barb_route_cache, point.x, point.y, vp.rotation);
-        tb.Finalize();
-        tb.draw(dc.GetDC());
-    } else
-        wind_barb_route_cache.draw(NULL);
+    wind_barb_route_cache.draw(dc.GetDC());
 
 #ifdef ocpnUSE_GL
     if(!dc.GetDC()) {


### PR DESCRIPTION
Hi,
I'm not sure I've got all issues.
- move offsetting in pushTransformedBuffer which knows arrow size and do it with the proper
rotation. 
- There's no cache so use the current viewport and don't re-rotate, it's done with
the viewport.

Now you can display:
![capture du 2018-06-21 18 01 12](https://user-images.githubusercontent.com/12138026/41734674-f4fcd45c-7587-11e8-9497-f30a335ff616.png)

Regards
Didier

