### PR TITLE
FIX windBarbOnRoute display issue

### DIFF
--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -745,6 +745,10 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
 #ifdef ocpnUSE_GL
     else
     {
+        // Mandatory to avoid display issue when moving map
+        // (map disappear to show a gray background...)
+        glPushMatrix();
+        
         // Anti-aliasing options to render
         // wind barbs at best quality (copy from grip_pi)
         glEnable(GL_BLEND);


### PR DESCRIPTION
glPushMatrix() was omitted when refactoring code and it generates
a display issue when moving map (map disappear to show a
gray background...).

Example:
<img width="905" alt="capture d ecran 2018-09-04 a 21 33 49" src="https://user-images.githubusercontent.com/22415254/45053711-17bcec00-b08b-11e8-8e11-77e161c22430.png">
