### PR TITLE
Add sizeable wind barb arrow

### DIFF
--- a/WeatherRouting.fbp
+++ b/WeatherRouting.fbp
@@ -2435,6 +2435,177 @@
                                                         <event name="OnUpdateUI"></event>
                                                     </object>
                                                 </object>
+                                                <object class="sizeritem" expanded="1">
+                                                    <property name="border">5</property>
+                                                    <property name="flag">wxALL</property>
+                                                    <property name="proportion">0</property>
+                                                    <object class="wxStaticText" expanded="1">
+                                                        <property name="BottomDockable">1</property>
+                                                        <property name="LeftDockable">1</property>
+                                                        <property name="RightDockable">1</property>
+                                                        <property name="TopDockable">1</property>
+                                                        <property name="aui_layer"></property>
+                                                        <property name="aui_name"></property>
+                                                        <property name="aui_position"></property>
+                                                        <property name="aui_row"></property>
+                                                        <property name="best_size"></property>
+                                                        <property name="bg"></property>
+                                                        <property name="caption"></property>
+                                                        <property name="caption_visible">1</property>
+                                                        <property name="center_pane">0</property>
+                                                        <property name="close_button">1</property>
+                                                        <property name="context_help"></property>
+                                                        <property name="context_menu">1</property>
+                                                        <property name="default_pane">0</property>
+                                                        <property name="dock">Dock</property>
+                                                        <property name="dock_fixed">0</property>
+                                                        <property name="docking">Left</property>
+                                                        <property name="enabled">1</property>
+                                                        <property name="fg"></property>
+                                                        <property name="floatable">1</property>
+                                                        <property name="font"></property>
+                                                        <property name="gripper">0</property>
+                                                        <property name="hidden">0</property>
+                                                        <property name="id">wxID_ANY</property>
+                                                        <property name="label">Wind Barbs On Route Thickness</property>
+                                                        <property name="max_size"></property>
+                                                        <property name="maximize_button">0</property>
+                                                        <property name="maximum_size"></property>
+                                                        <property name="min_size"></property>
+                                                        <property name="minimize_button">0</property>
+                                                        <property name="minimum_size"></property>
+                                                        <property name="moveable">1</property>
+                                                        <property name="name">m_staticText711</property>
+                                                        <property name="pane_border">1</property>
+                                                        <property name="pane_position"></property>
+                                                        <property name="pane_size"></property>
+                                                        <property name="permission">protected</property>
+                                                        <property name="pin_button">1</property>
+                                                        <property name="pos"></property>
+                                                        <property name="resize">Resizable</property>
+                                                        <property name="show">1</property>
+                                                        <property name="size"></property>
+                                                        <property name="style"></property>
+                                                        <property name="subclass"></property>
+                                                        <property name="toolbar_pane">0</property>
+                                                        <property name="tooltip"></property>
+                                                        <property name="window_extra_style"></property>
+                                                        <property name="window_name"></property>
+                                                        <property name="window_style"></property>
+                                                        <property name="wrap">-1</property>
+                                                        <event name="OnChar"></event>
+                                                        <event name="OnEnterWindow"></event>
+                                                        <event name="OnEraseBackground"></event>
+                                                        <event name="OnKeyDown"></event>
+                                                        <event name="OnKeyUp"></event>
+                                                        <event name="OnKillFocus"></event>
+                                                        <event name="OnLeaveWindow"></event>
+                                                        <event name="OnLeftDClick"></event>
+                                                        <event name="OnLeftDown"></event>
+                                                        <event name="OnLeftUp"></event>
+                                                        <event name="OnMiddleDClick"></event>
+                                                        <event name="OnMiddleDown"></event>
+                                                        <event name="OnMiddleUp"></event>
+                                                        <event name="OnMotion"></event>
+                                                        <event name="OnMouseEvents"></event>
+                                                        <event name="OnMouseWheel"></event>
+                                                        <event name="OnPaint"></event>
+                                                        <event name="OnRightDClick"></event>
+                                                        <event name="OnRightDown"></event>
+                                                        <event name="OnRightUp"></event>
+                                                        <event name="OnSetFocus"></event>
+                                                        <event name="OnSize"></event>
+                                                        <event name="OnUpdateUI"></event>
+                                                    </object>
+                                                </object>
+                                                <object class="sizeritem" expanded="1">
+                                                    <property name="border">5</property>
+                                                    <property name="flag">wxALL</property>
+                                                    <property name="proportion">0</property>
+                                                    <object class="wxSpinCtrl" expanded="1">
+                                                        <property name="BottomDockable">1</property>
+                                                        <property name="LeftDockable">1</property>
+                                                        <property name="RightDockable">1</property>
+                                                        <property name="TopDockable">1</property>
+                                                        <property name="aui_layer"></property>
+                                                        <property name="aui_name"></property>
+                                                        <property name="aui_position"></property>
+                                                        <property name="aui_row"></property>
+                                                        <property name="best_size"></property>
+                                                        <property name="bg"></property>
+                                                        <property name="caption"></property>
+                                                        <property name="caption_visible">1</property>
+                                                        <property name="center_pane">0</property>
+                                                        <property name="close_button">1</property>
+                                                        <property name="context_help"></property>
+                                                        <property name="context_menu">1</property>
+                                                        <property name="default_pane">0</property>
+                                                        <property name="dock">Dock</property>
+                                                        <property name="dock_fixed">0</property>
+                                                        <property name="docking">Left</property>
+                                                        <property name="enabled">1</property>
+                                                        <property name="fg"></property>
+                                                        <property name="floatable">1</property>
+                                                        <property name="font"></property>
+                                                        <property name="gripper">0</property>
+                                                        <property name="hidden">0</property>
+                                                        <property name="id">wxID_ANY</property>
+                                                        <property name="initial">2</property>
+                                                        <property name="max">6</property>
+                                                        <property name="max_size"></property>
+                                                        <property name="maximize_button">0</property>
+                                                        <property name="maximum_size"></property>
+                                                        <property name="min">0</property>
+                                                        <property name="min_size"></property>
+                                                        <property name="minimize_button">0</property>
+                                                        <property name="minimum_size"></property>
+                                                        <property name="moveable">1</property>
+                                                        <property name="name">m_sWindBarbsOnRouteThickness</property>
+                                                        <property name="pane_border">1</property>
+                                                        <property name="pane_position"></property>
+                                                        <property name="pane_size"></property>
+                                                        <property name="permission">public</property>
+                                                        <property name="pin_button">1</property>
+                                                        <property name="pos"></property>
+                                                        <property name="resize">Resizable</property>
+                                                        <property name="show">1</property>
+                                                        <property name="size"></property>
+                                                        <property name="style">wxSP_ARROW_KEYS</property>
+                                                        <property name="subclass"></property>
+                                                        <property name="toolbar_pane">0</property>
+                                                        <property name="tooltip"></property>
+                                                        <property name="value"></property>
+                                                        <property name="window_extra_style"></property>
+                                                        <property name="window_name"></property>
+                                                        <property name="window_style"></property>
+                                                        <event name="OnChar"></event>
+                                                        <event name="OnEnterWindow"></event>
+                                                        <event name="OnEraseBackground"></event>
+                                                        <event name="OnKeyDown"></event>
+                                                        <event name="OnKeyUp"></event>
+                                                        <event name="OnKillFocus"></event>
+                                                        <event name="OnLeaveWindow"></event>
+                                                        <event name="OnLeftDClick"></event>
+                                                        <event name="OnLeftDown"></event>
+                                                        <event name="OnLeftUp"></event>
+                                                        <event name="OnMiddleDClick"></event>
+                                                        <event name="OnMiddleDown"></event>
+                                                        <event name="OnMiddleUp"></event>
+                                                        <event name="OnMotion"></event>
+                                                        <event name="OnMouseEvents"></event>
+                                                        <event name="OnMouseWheel"></event>
+                                                        <event name="OnPaint"></event>
+                                                        <event name="OnRightDClick"></event>
+                                                        <event name="OnRightDown"></event>
+                                                        <event name="OnRightUp"></event>
+                                                        <event name="OnSetFocus"></event>
+                                                        <event name="OnSize"></event>
+                                                        <event name="OnSpinCtrl">OnUpdateSpin</event>
+                                                        <event name="OnSpinCtrlText"></event>
+                                                        <event name="OnTextEnter"></event>
+                                                        <event name="OnUpdateUI"></event>
+                                                    </object>
+                                                </object>
                                             </object>
                                         </object>
                                         <object class="sizeritem" expanded="0">
@@ -2847,94 +3018,6 @@
                                                         <property name="minimum_size"></property>
                                                         <property name="moveable">1</property>
                                                         <property name="name">m_cbDisplayWindBarbs</property>
-                                                        <property name="pane_border">1</property>
-                                                        <property name="pane_position"></property>
-                                                        <property name="pane_size"></property>
-                                                        <property name="permission">public</property>
-                                                        <property name="pin_button">1</property>
-                                                        <property name="pos"></property>
-                                                        <property name="resize">Resizable</property>
-                                                        <property name="show">1</property>
-                                                        <property name="size"></property>
-                                                        <property name="style"></property>
-                                                        <property name="subclass"></property>
-                                                        <property name="toolbar_pane">0</property>
-                                                        <property name="tooltip"></property>
-                                                        <property name="validator_data_type"></property>
-                                                        <property name="validator_style">wxFILTER_NONE</property>
-                                                        <property name="validator_type">wxDefaultValidator</property>
-                                                        <property name="validator_variable"></property>
-                                                        <property name="window_extra_style"></property>
-                                                        <property name="window_name"></property>
-                                                        <property name="window_style"></property>
-                                                        <event name="OnChar"></event>
-                                                        <event name="OnCheckBox">OnUpdate</event>
-                                                        <event name="OnEnterWindow"></event>
-                                                        <event name="OnEraseBackground"></event>
-                                                        <event name="OnKeyDown"></event>
-                                                        <event name="OnKeyUp"></event>
-                                                        <event name="OnKillFocus"></event>
-                                                        <event name="OnLeaveWindow"></event>
-                                                        <event name="OnLeftDClick"></event>
-                                                        <event name="OnLeftDown"></event>
-                                                        <event name="OnLeftUp"></event>
-                                                        <event name="OnMiddleDClick"></event>
-                                                        <event name="OnMiddleDown"></event>
-                                                        <event name="OnMiddleUp"></event>
-                                                        <event name="OnMotion"></event>
-                                                        <event name="OnMouseEvents"></event>
-                                                        <event name="OnMouseWheel"></event>
-                                                        <event name="OnPaint"></event>
-                                                        <event name="OnRightDClick"></event>
-                                                        <event name="OnRightDown"></event>
-                                                        <event name="OnRightUp"></event>
-                                                        <event name="OnSetFocus"></event>
-                                                        <event name="OnSize"></event>
-                                                        <event name="OnUpdateUI"></event>
-                                                    </object>
-                                                </object>
-                                                <object class="sizeritem" expanded="0">
-                                                    <property name="border">5</property>
-                                                    <property name="flag">wxALL</property>
-                                                    <property name="proportion">0</property>
-                                                    <object class="wxCheckBox" expanded="0">
-                                                        <property name="BottomDockable">1</property>
-                                                        <property name="LeftDockable">1</property>
-                                                        <property name="RightDockable">1</property>
-                                                        <property name="TopDockable">1</property>
-                                                        <property name="aui_layer"></property>
-                                                        <property name="aui_name"></property>
-                                                        <property name="aui_position"></property>
-                                                        <property name="aui_row"></property>
-                                                        <property name="best_size"></property>
-                                                        <property name="bg"></property>
-                                                        <property name="caption"></property>
-                                                        <property name="caption_visible">1</property>
-                                                        <property name="center_pane">0</property>
-                                                        <property name="checked">0</property>
-                                                        <property name="close_button">1</property>
-                                                        <property name="context_help"></property>
-                                                        <property name="context_menu">1</property>
-                                                        <property name="default_pane">0</property>
-                                                        <property name="dock">Dock</property>
-                                                        <property name="dock_fixed">0</property>
-                                                        <property name="docking">Left</property>
-                                                        <property name="enabled">1</property>
-                                                        <property name="fg"></property>
-                                                        <property name="floatable">1</property>
-                                                        <property name="font"></property>
-                                                        <property name="gripper">0</property>
-                                                        <property name="hidden">0</property>
-                                                        <property name="id">wxID_ANY</property>
-                                                        <property name="label">Display Wind Barbs On Route</property>
-                                                        <property name="max_size"></property>
-                                                        <property name="maximize_button">0</property>
-                                                        <property name="maximum_size"></property>
-                                                        <property name="min_size"></property>
-                                                        <property name="minimize_button">0</property>
-                                                        <property name="minimum_size"></property>
-                                                        <property name="moveable">1</property>
-                                                        <property name="name">m_cbDisplayWindBarbsOnRoute</property>
                                                         <property name="pane_border">1</property>
                                                         <property name="pane_position"></property>
                                                         <property name="pane_size"></property>
@@ -3566,7 +3649,7 @@
             <event name="OnSetFocus"></event>
             <event name="OnSize"></event>
             <event name="OnUpdateUI"></event>
-            <object class="wxFlexGridSizer" expanded="1">
+            <object class="wxFlexGridSizer" expanded="0">
                 <property name="cols">2</property>
                 <property name="flexible_direction">wxBOTH</property>
                 <property name="growablecols">0,1</property>
@@ -3578,11 +3661,11 @@
                 <property name="permission">none</property>
                 <property name="rows">0</property>
                 <property name="vgap">0</property>
-                <object class="sizeritem" expanded="1">
+                <object class="sizeritem" expanded="0">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND | wxALL</property>
                     <property name="proportion">1</property>
-                    <object class="wxNotebook" expanded="1">
+                    <object class="wxNotebook" expanded="0">
                         <property name="BottomDockable">1</property>
                         <property name="LeftDockable">1</property>
                         <property name="RightDockable">1</property>
@@ -7325,11 +7408,11 @@
                                 </object>
                             </object>
                         </object>
-                        <object class="notebookpage" expanded="1">
+                        <object class="notebookpage" expanded="0">
                             <property name="bitmap"></property>
                             <property name="label">Advanced</property>
                             <property name="select">0</property>
-                            <object class="wxPanel" expanded="1">
+                            <object class="wxPanel" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -7403,7 +7486,7 @@
                                 <event name="OnSetFocus"></event>
                                 <event name="OnSize"></event>
                                 <event name="OnUpdateUI"></event>
-                                <object class="wxFlexGridSizer" expanded="1">
+                                <object class="wxFlexGridSizer" expanded="0">
                                     <property name="cols">2</property>
                                     <property name="flexible_direction">wxBOTH</property>
                                     <property name="growablecols">0,1</property>
@@ -7415,11 +7498,11 @@
                                     <property name="permission">none</property>
                                     <property name="rows">0</property>
                                     <property name="vgap">0</property>
-                                    <object class="sizeritem" expanded="1">
+                                    <object class="sizeritem" expanded="0">
                                         <property name="border">5</property>
                                         <property name="flag">wxEXPAND</property>
                                         <property name="proportion">1</property>
-                                        <object class="wxFlexGridSizer" expanded="1">
+                                        <object class="wxFlexGridSizer" expanded="0">
                                             <property name="cols">1</property>
                                             <property name="flexible_direction">wxBOTH</property>
                                             <property name="growablecols">0</property>
@@ -7431,11 +7514,11 @@
                                             <property name="permission">none</property>
                                             <property name="rows">0</property>
                                             <property name="vgap">0</property>
-                                            <object class="sizeritem" expanded="1">
+                                            <object class="sizeritem" expanded="0">
                                                 <property name="border">5</property>
                                                 <property name="flag">wxEXPAND</property>
                                                 <property name="proportion">1</property>
-                                                <object class="wxStaticBoxSizer" expanded="1">
+                                                <object class="wxStaticBoxSizer" expanded="0">
                                                     <property name="id">wxID_ANY</property>
                                                     <property name="label">Constraints</property>
                                                     <property name="minimum_size"></property>
@@ -7444,7 +7527,7 @@
                                                     <property name="parent">1</property>
                                                     <property name="permission">none</property>
                                                     <event name="OnUpdateUI"></event>
-                                                    <object class="sizeritem" expanded="1">
+                                                    <object class="sizeritem" expanded="0">
                                                         <property name="border">5</property>
                                                         <property name="flag">wxEXPAND</property>
                                                         <property name="proportion">1</property>
@@ -8405,11 +8488,11 @@
                                                             </object>
                                                         </object>
                                                     </object>
-                                                    <object class="sizeritem" expanded="1">
+                                                    <object class="sizeritem" expanded="0">
                                                         <property name="border">5</property>
                                                         <property name="flag">wxEXPAND</property>
                                                         <property name="proportion">1</property>
-                                                        <object class="wxFlexGridSizer" expanded="1">
+                                                        <object class="wxFlexGridSizer" expanded="0">
                                                             <property name="cols">1</property>
                                                             <property name="flexible_direction">wxBOTH</property>
                                                             <property name="growablecols"></property>
@@ -8509,11 +8592,11 @@
                                                                     <event name="OnUpdateUI"></event>
                                                                 </object>
                                                             </object>
-                                                            <object class="sizeritem" expanded="1">
+                                                            <object class="sizeritem" expanded="0">
                                                                 <property name="border">5</property>
                                                                 <property name="flag">wxEXPAND</property>
                                                                 <property name="proportion">1</property>
-                                                                <object class="wxFlexGridSizer" expanded="1">
+                                                                <object class="wxFlexGridSizer" expanded="0">
                                                                     <property name="cols">5</property>
                                                                     <property name="flexible_direction">wxBOTH</property>
                                                                     <property name="growablecols"></property>
@@ -8958,11 +9041,11 @@
                                             </object>
                                         </object>
                                     </object>
-                                    <object class="sizeritem" expanded="1">
+                                    <object class="sizeritem" expanded="0">
                                         <property name="border">5</property>
                                         <property name="flag">wxEXPAND</property>
                                         <property name="proportion">1</property>
-                                        <object class="wxFlexGridSizer" expanded="1">
+                                        <object class="wxFlexGridSizer" expanded="0">
                                             <property name="cols">1</property>
                                             <property name="flexible_direction">wxBOTH</property>
                                             <property name="growablecols">0</property>
@@ -10034,11 +10117,11 @@
                                                                             <event name="OnUpdateUI"></event>
                                                                         </object>
                                                                     </object>
-                                                                    <object class="sizeritem" expanded="1">
+                                                                    <object class="sizeritem" expanded="0">
                                                                         <property name="border">5</property>
                                                                         <property name="flag">wxALL</property>
                                                                         <property name="proportion">0</property>
-                                                                        <object class="wxSpinCtrl" expanded="1">
+                                                                        <object class="wxSpinCtrl" expanded="0">
                                                                             <property name="BottomDockable">1</property>
                                                                             <property name="LeftDockable">1</property>
                                                                             <property name="RightDockable">1</property>
@@ -10211,7 +10294,7 @@
                                                     </object>
                                                 </object>
                                             </object>
-                                            <object class="sizeritem" expanded="1">
+                                            <object class="sizeritem" expanded="0">
                                                 <property name="border">5</property>
                                                 <property name="flag">wxEXPAND</property>
                                                 <property name="proportion">1</property>

--- a/src/LineBufferOverlay.cpp
+++ b/src/LineBufferOverlay.cpp
@@ -98,7 +98,7 @@ void LineBuffer::draw(wxDC *dc)
 
 void WindBarbLineBuffer::pushPetiteBarbule( int b, int lineWidth )
 {
-    pushLine( 0, b, -(4 * (lineWidth/DEFAULT_WIND_ARROW_SIZE_FACTOR)), b - 2 );
+    pushLine( 0, b, -(5 * (lineWidth/DEFAULT_WIND_ARROW_SIZE_FACTOR)), b - 2 );
 }
 
 void WindBarbLineBuffer::pushGrandeBarbule( int b, int lineWidth )

--- a/src/LineBufferOverlay.cpp
+++ b/src/LineBufferOverlay.cpp
@@ -49,7 +49,7 @@ void LineBuffer::Finalize()
     buffer.clear();
 }
 
-void LineBuffer::pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south, bool head)
+void LineBuffer::pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south, bool head, int lineWidth)
 {
     // transform vertexes by angle
     float sa = sinf( ang ), ca = cosf( ang );
@@ -62,11 +62,11 @@ void LineBuffer::pushTransformedBuffer(LineBuffer &buffer, int x, int y, double 
         m[1][0] = -m[1][0];
     }
     if(head) {
-        // Calculate the offset to put the head
-        // of the arrow on the point (and not the
-        // middle of the arrow).
-        x += (int)(0.5 * 35 * sa);
-        y -= (int)(0.5 * 35 * ca);
+        // Calculate the offset to put the head of the arrow on the point
+        // (and not the middle of the arrow taking into account lineWidth).
+        const int windArrowSize = (int)(DEFAULT_WIND_ARROW_SIZE * (lineWidth/DEFAULT_WIND_ARROW_SIZE_FACTOR));
+        x += (int)((windArrowSize / 2 + lineWidth) * sa);
+        y -= (int)((windArrowSize / 2 + lineWidth) * ca);
     }
 
     for(int i=0; i < 2*buffer.count; i+=2) {
@@ -96,21 +96,22 @@ void LineBuffer::draw(wxDC *dc)
     }
 }
 
-void WindBarbLineBuffer::pushPetiteBarbule( int b )
+void WindBarbLineBuffer::pushPetiteBarbule( int b, int lineWidth )
 {
-    pushLine( 0, b, -5, b - 2 );
+    pushLine( 0, b, -(4 * (lineWidth/DEFAULT_WIND_ARROW_SIZE_FACTOR)), b - 2 );
 }
 
-void WindBarbLineBuffer::pushGrandeBarbule( int b )
+void WindBarbLineBuffer::pushGrandeBarbule( int b, int lineWidth )
 {
-    pushLine( 0, b, -10, b - 4 );
+    pushLine( 0, b, -(10 * (lineWidth/DEFAULT_WIND_ARROW_SIZE_FACTOR)), b - 4 );
 }
 
-void WindBarbLineBuffer::pushTriangle( int b )
+void WindBarbLineBuffer::pushTriangle( int b, int lineWidth )
 {
     pushLine( 0, b,     -10, b - 4 );
     pushLine( 0, b - 8, -10, b - 4 );
 }
+
 
 LineBufferOverlay g_LineBufferOverlay;
 // Customization WindBarbsOnRoute
@@ -118,11 +119,28 @@ LineBufferOverlay g_barbsOnRoute_LineBufferOverlay;
 
 LineBufferOverlay::LineBufferOverlay()
 {
-    const int windArrowSize = 26;   //set arrow size
+    m_lineWidth = 2;
+    setLineBuffer();
+}
+
+void LineBufferOverlay::setLineWidth(int lineWidth)
+{
+    m_lineWidth = lineWidth;
+    setLineBuffer();
+}
+
+void LineBufferOverlay::setLineBuffer()
+{
+    // Set arrow size
+    // which is proportional to the line width of the barbs
+    const int windArrowSize = (int)(DEFAULT_WIND_ARROW_SIZE * (m_lineWidth/DEFAULT_WIND_ARROW_SIZE_FACTOR));
 
     // Generate the wind arrow cache
-
-    int r = 5, i=0;     // wind is very light, draw a circle
+    
+    // Wind is very light, draw a circle
+    // also proportional to line width
+    int r = 2 * m_lineWidth;
+    int i=0;
     double s = 2 * M_PI / 10.;
     for( double a = 0; a < 2 * M_PI; a += s )
         m_WindArrowCache[0].pushLine(r*sin(a), r*cos(a), r*sin(a+s), r*cos(a+s));
@@ -134,41 +152,44 @@ LineBufferOverlay::LineBufferOverlay()
         LineBuffer &arrow = m_WindArrowCache[i];
 
         arrow.pushLine( 0, dec,  0, dec - windArrowSize );   // hampe
-        arrow.pushLine( 0, dec,  2, dec - 5 );    // flèche
-        arrow.pushLine( 0, dec, -2, dec - 5 );   // flèche
+        // Right arrow
+        arrow.pushLine(0, dec - ceil(m_lineWidth / 2 * sqrt(2)), round(dec/4 + (m_lineWidth / 2 * sqrt(2))), round(dec/2));
+        // Left arrow
+        arrow.pushLine(0, dec - ceil(m_lineWidth / 2 * sqrt(2)), round(-dec/4 - (m_lineWidth / 2 * sqrt(2))), round(dec/2));
     }
 
-    int b1 = dec - windArrowSize + 4;  // position de la 1ère barbule
-    int b2 = dec - windArrowSize;  // position de la 1ère barbule si >= 10 noeuds
+    float alpha = 0.38;
+    int b1 = dec - windArrowSize + (2 * m_lineWidth) + ceil((m_lineWidth/2) * sin(alpha));  // Position of 1st barb
+    int b2 = dec - windArrowSize + round((m_lineWidth/2) * sin(alpha));                    // Position of 2nd barb if >= 10 knts
 
     // 5 ktn
-    m_WindArrowCache[1].pushPetiteBarbule( b1 );
+    m_WindArrowCache[1].pushPetiteBarbule( b1, m_lineWidth );
     // 10 ktn
-    m_WindArrowCache[2].pushGrandeBarbule( b2 );
+    m_WindArrowCache[2].pushGrandeBarbule( b2, m_lineWidth );
     // 15 ktn
-    m_WindArrowCache[3].pushGrandeBarbule( b2 );
-    m_WindArrowCache[3].pushPetiteBarbule( b2 + 4 );
+    m_WindArrowCache[3].pushGrandeBarbule( b2, m_lineWidth );
+    m_WindArrowCache[3].pushPetiteBarbule( b2 + (2 * m_lineWidth), m_lineWidth );
     // 20 ktn
-    m_WindArrowCache[4].pushGrandeBarbule( b2 );
-    m_WindArrowCache[4].pushGrandeBarbule( b2 + 4 );
+    m_WindArrowCache[4].pushGrandeBarbule( b2, m_lineWidth );
+    m_WindArrowCache[4].pushGrandeBarbule( b2 + (2 * m_lineWidth), m_lineWidth );
     // 25 ktn
-    m_WindArrowCache[5].pushGrandeBarbule( b2 );
-    m_WindArrowCache[5].pushGrandeBarbule( b2 + 4 );
-    m_WindArrowCache[5].pushPetiteBarbule( b2 + 8 );
+    m_WindArrowCache[5].pushGrandeBarbule( b2, m_lineWidth );
+    m_WindArrowCache[5].pushGrandeBarbule( b2 + (2 * m_lineWidth), m_lineWidth );
+    m_WindArrowCache[5].pushPetiteBarbule( b2 + (4 * m_lineWidth), m_lineWidth );
     // 30 ktn
-    m_WindArrowCache[6].pushGrandeBarbule( b2 );
-    m_WindArrowCache[6].pushGrandeBarbule( b2 + 4 );
-    m_WindArrowCache[6].pushGrandeBarbule( b2 + 8 );
+    m_WindArrowCache[6].pushGrandeBarbule( b2, m_lineWidth );
+    m_WindArrowCache[6].pushGrandeBarbule( b2 + (2 * m_lineWidth), m_lineWidth );
+    m_WindArrowCache[6].pushGrandeBarbule( b2 + (4 * m_lineWidth), m_lineWidth );
     // 35 ktn
-    m_WindArrowCache[7].pushGrandeBarbule( b2 );
-    m_WindArrowCache[7].pushGrandeBarbule( b2 + 4 );
-    m_WindArrowCache[7].pushGrandeBarbule( b2 + 8 );
-    m_WindArrowCache[7].pushPetiteBarbule( b2 + 12 );
+    m_WindArrowCache[7].pushGrandeBarbule( b2, m_lineWidth );
+    m_WindArrowCache[7].pushGrandeBarbule( b2 + (2 * m_lineWidth), m_lineWidth );
+    m_WindArrowCache[7].pushGrandeBarbule( b2 + (4 * m_lineWidth), m_lineWidth );
+    m_WindArrowCache[7].pushPetiteBarbule( b2 + (6 * m_lineWidth), m_lineWidth );
     // 40 ktn
-    m_WindArrowCache[8].pushGrandeBarbule( b2 );
-    m_WindArrowCache[8].pushGrandeBarbule( b2 + 4 );
-    m_WindArrowCache[8].pushGrandeBarbule( b2 + 8 );
-    m_WindArrowCache[8].pushGrandeBarbule( b2 + 12 );
+    m_WindArrowCache[8].pushGrandeBarbule( b2, m_lineWidth );
+    m_WindArrowCache[8].pushGrandeBarbule( b2 + (2 * m_lineWidth), m_lineWidth );
+    m_WindArrowCache[8].pushGrandeBarbule( b2 + (4 * m_lineWidth), m_lineWidth );
+    m_WindArrowCache[8].pushGrandeBarbule( b2 + (6 * m_lineWidth), m_lineWidth );
     // 50 ktn
     m_WindArrowCache[9].pushTriangle( b1 + 4 );
     // 60 ktn
@@ -228,7 +249,7 @@ void LineBufferOverlay::pushWindArrowWithBarbs(LineBuffer &buffer, int x, int y,
         cacheidx = 13;
     else 
         return;
-    buffer.pushTransformedBuffer(m_WindArrowCache[cacheidx], x, y, ang, south, head);
+    buffer.pushTransformedBuffer(m_WindArrowCache[cacheidx], x, y, ang, south, head, m_lineWidth);
 }
 
 void LineBufferOverlay::pushSingleArrow( LineBuffer &buffer, int x, int y, double vkn, double ang, bool south)

--- a/src/LineBufferOverlay.h
+++ b/src/LineBufferOverlay.h
@@ -27,6 +27,10 @@
 
 #include <list>
 
+#define DEFAULT_WIND_ARROW_SIZE 26
+#define DEFAULT_WIND_ARROW_SIZE_FACTOR 2.3
+#define DEFAULT_WIND_ARROW_LINE_WIDTH 2
+
 class LineBuffer {
 public:
     LineBuffer() { count = 0; lines = NULL; }
@@ -35,7 +39,7 @@ public:
     void pushLine( float x0, float y0, float x1, float y1 );
     void Finalize();
 
-    void pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south=false, bool head=false);
+    void pushTransformedBuffer(LineBuffer &buffer, int x, int y, double ang, bool south=false, bool head=false, int lineWidth=DEFAULT_WIND_ARROW_SIZE);
     void draw(wxDC *dc);
     void drawTransformed(wxDC *dc, wxPoint offset, double ang);
 
@@ -49,21 +53,24 @@ private:
 class WindBarbLineBuffer : public LineBuffer
 {
 public:
-    void pushPetiteBarbule( int b );
-    void pushGrandeBarbule( int b );
-    void pushTriangle( int b );
+    void pushPetiteBarbule( int b, int lineWidth=DEFAULT_WIND_ARROW_SIZE );
+    void pushGrandeBarbule( int b, int lineWidth=DEFAULT_WIND_ARROW_SIZE );
+    void pushTriangle( int b, int lineWidth=DEFAULT_WIND_ARROW_SIZE );
 };
 
 class LineBufferOverlay
 {
 public:
     LineBufferOverlay();
+    void setLineBuffer();
+    void setLineWidth(int lineWidth);
     void pushWindArrowWithBarbs(LineBuffer &buffer, int x, int y, double vkn, double ang, bool south=false, bool head=false);
     void pushSingleArrow( LineBuffer &buffer, int x, int y, double vkn, double ang, bool south=false);
 private:
 
     WindBarbLineBuffer m_WindArrowCache[14];
     LineBuffer m_SingleArrow[14];
+    int m_lineWidth;
 };
 
 extern LineBufferOverlay g_LineBufferOverlay;

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -698,8 +698,12 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
      * OpenCPN's licence
      * March, 2018
      */
+    
     if (vp.bValid == false)
         return;
+    
+    // Config line width of the wind barb
+    int lineWidth = 4;
 
     RouteMapConfiguration configuration = GetConfiguration();
 
@@ -725,6 +729,7 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
         double W = it->W;
         
         // Draw barbs
+        g_barbsOnRoute_LineBufferOverlay.setLineWidth(lineWidth);
         g_barbsOnRoute_LineBufferOverlay.pushWindArrowWithBarbs(
             wind_barb_route_cache, p.x, p.y, VW,
             deg2rad(W) + nvp.rotation, it->lat < 0, true
@@ -757,11 +762,11 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
         glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
         
         glColor3ub(colour.Red(), colour.Green(), colour.Blue());
-        glLineWidth(2);
+        glLineWidth(lineWidth);
         glEnableClientState(GL_VERTEX_ARRAY);
     }
 #endif
-    
+
     wind_barb_route_cache.draw(dc.GetDC());
 
 #ifdef ocpnUSE_GL

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -454,8 +454,9 @@ void RouteMapOverlay::Render(wxDateTime time, SettingsDialog &settingsdialog,
         RenderBoatOnCourse(false, time, dc, vp);
 
         // Start WindBarbsOnRoute customization
-        if (settingsdialog.m_cbDisplayWindBarbsOnRoute->GetValue())
-            RenderWindBarbsOnRoute(dc, vp);
+        int lineWidth = settingsdialog.m_sWindBarbsOnRouteThickness->GetValue();
+        if (lineWidth > 0)
+            RenderWindBarbsOnRoute(dc, vp, lineWidth);
         
         if(MarkAtPolarChange) {
             SetColor(dc, Darken(DestinationColor), true);
@@ -688,7 +689,7 @@ void RouteMapOverlay::RenderBoatOnCourse(bool cursor_route, wxDateTime time, wrD
     }
 }
 
-void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
+void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp, int lineWidth)
 {
     /* Method to render wind barbs on the route that has been generated
      * by WeatherRouting plugin. The idead is to visualize the wind
@@ -701,9 +702,6 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp)
     
     if (vp.bValid == false)
         return;
-    
-    // Config line width of the wind barb
-    int lineWidth = 4;
 
     RouteMapConfiguration configuration = GetConfiguration();
 

--- a/src/RouteMapOverlay.h
+++ b/src/RouteMapOverlay.h
@@ -105,7 +105,7 @@ private:
     void RenderCourse(bool cursor_route, wrDC &dc, PlugIn_ViewPort &vp, bool comfortRoute = false);
 
     // Customization WindBarbsOnRoute
-    void RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp);
+    void RenderWindBarbsOnRoute(wrDC &dc, PlugIn_ViewPort &vp, int lineWidth);
     int sailingConditionLevel(const PlotData &plot) const;
 
     virtual bool TestAbort() { return Finished(); }

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -100,10 +100,10 @@ void SettingsDialog::LoadSettings()
     m_cbDisplayWindBarbs->SetValue(DisplayWindBarbs);
     
     // WindBarbsOnRoute Customization
-    bool DisplayWindBarbsOnRoute = m_cbDisplayWindBarbsOnRoute->GetValue();
-    pConf->Read( _T("DisplayWindBarbsOnRoute"), &DisplayWindBarbsOnRoute,
-                DisplayWindBarbsOnRoute);
-    m_cbDisplayWindBarbsOnRoute->SetValue(DisplayWindBarbsOnRoute);
+    int WindBarbsOnRouteThickness = m_sWindBarbsOnRouteThickness->GetValue();
+    pConf->Read( _T("WindBarbsOnRouteThickness"), &WindBarbsOnRouteThickness,
+                WindBarbsOnRouteThickness);
+    m_sWindBarbsOnRouteThickness->SetValue(WindBarbsOnRouteThickness);
     
     // ComfortOnRoute Customization
     bool DisplayComfortOnRoute = m_cbDisplayComfort->GetValue();
@@ -159,7 +159,7 @@ void SettingsDialog::SaveSettings( )
     pConf->Write( _T("MarkAtPolarChange"), m_cbMarkAtPolarChange->GetValue());
     pConf->Write( _T("DisplayWindBarbs"), m_cbDisplayWindBarbs->GetValue());
     // WindBarbsOnRoute Customization
-    pConf->Write( _T("DisplayWindBarbsOnRoute"), m_cbDisplayWindBarbsOnRoute->GetValue());
+    pConf->Write( _T("WindBarbsOnRouteThickness"), m_sWindBarbsOnRouteThickness->GetValue());
     pConf->Write( _T("DisplayComfortOnRoute"), m_cbDisplayComfort->GetValue());
     pConf->Write( _T("DisplayCurrent"), m_cbDisplayCurrent->GetValue());
 

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -387,6 +387,13 @@ SettingsDialogBase::SettingsDialogBase( wxWindow* parent, wxWindowID id, const w
 	m_sAlternateRouteThickness = new wxSpinCtrl( sbSizer25->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 10, 0 );
 	fgSizer42->Add( m_sAlternateRouteThickness, 0, wxALL, 5 );
 	
+	m_staticText711 = new wxStaticText( sbSizer25->GetStaticBox(), wxID_ANY, _("Wind Barbs On Route Thickness"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText711->Wrap( -1 );
+	fgSizer42->Add( m_staticText711, 0, wxALL, 5 );
+	
+	m_sWindBarbsOnRouteThickness = new wxSpinCtrl( sbSizer25->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 6, 2 );
+	fgSizer42->Add( m_sWindBarbsOnRouteThickness, 0, wxALL, 5 );
+	
 	
 	fgSizer18->Add( fgSizer42, 1, wxEXPAND, 5 );
 	
@@ -412,9 +419,6 @@ SettingsDialogBase::SettingsDialogBase( wxWindow* parent, wxWindowID id, const w
 	
 	m_cbDisplayWindBarbs = new wxCheckBox( sbSizer25->GetStaticBox(), wxID_ANY, _("Display Wind Barbs"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer82->Add( m_cbDisplayWindBarbs, 0, wxALL, 5 );
-	
-	m_cbDisplayWindBarbsOnRoute = new wxCheckBox( sbSizer25->GetStaticBox(), wxID_ANY, _("Display Wind Barbs On Route"), wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer82->Add( m_cbDisplayWindBarbsOnRoute, 0, wxALL, 5 );
 	
 	m_cbDisplayComfort = new wxCheckBox( sbSizer25->GetStaticBox(), wxID_ANY, _("Display Sailing Comfort on Route"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer82->Add( m_cbDisplayComfort, 0, wxALL, 5 );
@@ -491,12 +495,12 @@ SettingsDialogBase::SettingsDialogBase( wxWindow* parent, wxWindowID id, const w
 	m_sRouteThickness->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
 	m_sIsoChronThickness->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
 	m_sAlternateRouteThickness->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
+	m_sWindBarbsOnRouteThickness->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
 	m_cbDisplayCursorRoute->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbAlternatesForAll->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbMarkAtPolarChange->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayCurrent->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayWindBarbs->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
-	m_cbDisplayWindBarbsOnRoute->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayComfort->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cblFields->Connect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );
 	m_cbUseLocalTime->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );
@@ -511,12 +515,12 @@ SettingsDialogBase::~SettingsDialogBase()
 	m_sRouteThickness->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
 	m_sIsoChronThickness->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
 	m_sAlternateRouteThickness->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
+	m_sWindBarbsOnRouteThickness->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( SettingsDialogBase::OnUpdateSpin ), NULL, this );
 	m_cbDisplayCursorRoute->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbAlternatesForAll->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbMarkAtPolarChange->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayCurrent->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayWindBarbs->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
-	m_cbDisplayWindBarbsOnRoute->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cbDisplayComfort->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdate ), NULL, this );
 	m_cblFields->Disconnect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );
 	m_cbUseLocalTime->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SettingsDialogBase::OnUpdateColumns ), NULL, this );

--- a/src/WeatherRoutingUI.h
+++ b/src/WeatherRoutingUI.h
@@ -171,6 +171,7 @@ class SettingsDialogBase : public wxDialog
 		wxStaticText* m_staticText75;
 		wxStaticText* m_staticText70;
 		wxStaticText* m_staticText71;
+		wxStaticText* m_staticText711;
 		wxStaticText* m_staticText115;
 		wxStdDialogButtonSizer* m_sdbSizer1;
 		wxButton* m_sdbSizer1OK;
@@ -190,12 +191,12 @@ class SettingsDialogBase : public wxDialog
 		wxSpinCtrl* m_sRouteThickness;
 		wxSpinCtrl* m_sIsoChronThickness;
 		wxSpinCtrl* m_sAlternateRouteThickness;
+		wxSpinCtrl* m_sWindBarbsOnRouteThickness;
 		wxCheckBox* m_cbDisplayCursorRoute;
 		wxCheckBox* m_cbAlternatesForAll;
 		wxCheckBox* m_cbMarkAtPolarChange;
 		wxCheckBox* m_cbDisplayCurrent;
 		wxCheckBox* m_cbDisplayWindBarbs;
-		wxCheckBox* m_cbDisplayWindBarbsOnRoute;
 		wxCheckBox* m_cbDisplayComfort;
 		wxSpinCtrl* m_sConcurrentThreads;
 		wxCheckListBox* m_cblFields;


### PR DESCRIPTION
I think this could be useful in some cases to have a sizeable wind barb arrow.
For example, in the case bellow, I have difficulty to see the WindBarbsOnRoute because of heavy density of wind barbs for the GRIB file.

Before:
<img width="892" alt="capture d ecran 2018-09-05 a 18 35 46" src="https://user-images.githubusercontent.com/22415254/45107712-c2d8ae80-b13a-11e8-898d-2c8f8478fe1f.png">

After:
<img width="926" alt="capture d ecran 2018-09-05 a 18 35 35" src="https://user-images.githubusercontent.com/22415254/45107720-c79d6280-b13a-11e8-97a1-9719f94879b1.png">
