### PR TITLE
Route position fix

### DIFF
--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -2341,7 +2341,7 @@ void WeatherRouting::Reset()
             reinterpret_cast<WeatherRoute*>(wxUIntToPtr(m_panel->m_lWeatherRoutes->GetItemData(i)));
         weatherroute->routemapoverlay->Reset();
     }
-
+    m_positionOnRoute = NULL;
     UpdateDialogs();
 
     GetParent()->Refresh();

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -602,7 +602,8 @@ void WeatherRouting::UpdateRoutePositionDialog()
     RoutePositionDialog &dlg = m_RoutePositionDialog;
     if(!dlg.IsShown())
         return;
-    
+
+    m_positionOnRoute = NULL;
     std::list<RouteMapOverlay*> currentroutemaps = CurrentRouteMaps();
     if(currentroutemaps.size() != 1) {
         RoutePositionDialogMessage(dlg, _("Select exactly 1 configuration"));

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -125,8 +125,8 @@ WeatherRouting::WeatherRouting(wxWindow *parent, weather_routing_pi &plugin)
       m_PlotDialog(*this), m_FilterRoutesDialog(this),
       m_bRunning(false), m_RoutesToRun(0), m_bSkipUpdateCurrentItems(false),
       m_bShowConfiguration(false), m_bShowConfigurationBatch(false),
-      m_bShowSettings(false), m_bShowStatistics(false),
-      m_bShowReport(false), m_bShowPlot(false),
+      m_bShowRoutePosition(false), m_bShowSettings(false),
+      m_bShowStatistics(false), m_bShowReport(false), m_bShowPlot(false),
       m_bShowFilter(false), m_weather_routing_pi(plugin),
       m_positionOnRoute(NULL)
 {
@@ -1259,6 +1259,7 @@ bool WeatherRouting::Show(bool show)
         m_ReportDialog.Show(m_bShowReport);
         m_PlotDialog.Show(m_bShowPlot);
         m_FilterRoutesDialog.Show(m_bShowFilter);
+        m_RoutePositionDialog.Show(m_bShowRoutePosition);
     } else {
         m_bShowConfiguration = m_ConfigurationDialog.IsShown();
         m_ConfigurationDialog.Hide();
@@ -1280,6 +1281,9 @@ bool WeatherRouting::Show(bool show)
 
         m_bShowFilter = m_FilterRoutesDialog.IsShown();
         m_FilterRoutesDialog.Hide();
+
+        m_bShowRoutePosition = m_RoutePositionDialog.IsShown();
+        m_RoutePositionDialog.Hide();
     }
 
     return WeatherRoutingBase::Show(show);

--- a/src/WeatherRouting.h
+++ b/src/WeatherRouting.h
@@ -208,7 +208,7 @@ private:
     int m_RoutesToRun;
     bool m_bSkipUpdateCurrentItems;
 
-    bool m_bShowConfiguration, m_bShowConfigurationBatch;
+    bool m_bShowConfiguration, m_bShowConfigurationBatch, m_bShowRoutePosition;
     bool m_bShowSettings, m_bShowStatistics, m_bShowReport, m_bShowPlot, m_bShowFilter;
 
     weather_routing_pi &m_weather_routing_pi;


### PR DESCRIPTION
Hi,
Route position is great but there's still some  rough edges.
On windows show/hide doesn't work by default, copy and paste code used for other dialogs.
If a displayed route is deleted don't display position circle.

Regards
Didier