### PR TITLE
Ability to stop computation of selected route

### DIFF
--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -203,7 +203,8 @@ private:
 
     void Start(RouteMapOverlay *routemapoverlay);
     void StartAll();
-    void Stop();
+    void Stop(RouteMapOverlay *routemapoverlay);
+    void StopAll();
 
     void DeleteRouteMaps(std::list<RouteMapOverlay *>routemapoverlays);
     RouteMapConfiguration DefaultConfiguration();

--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -200,10 +200,12 @@ private:
     RouteMap *SelectedRouteMap();
     void Export(RouteMapOverlay &routemapoverlay);
     void ExportRoute(RouteMapOverlay &routemapoverlay);
-
+    /* Start the computation of the selected route. */
     void Start(RouteMapOverlay *routemapoverlay);
     void StartAll();
+    /* Stop the computation of the selected routes. */
     void Stop(RouteMapOverlay *routemapoverlay);
+    /* Stop the computation of all routes. */
     void StopAll();
 
     void DeleteRouteMaps(std::list<RouteMapOverlay *>routemapoverlays);

--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -200,10 +200,10 @@ private:
     RouteMap *SelectedRouteMap();
     void Export(RouteMapOverlay &routemapoverlay);
     void ExportRoute(RouteMapOverlay &routemapoverlay);
-    /* Start the computation of the selected route. */
+    /* Start the computation of the specified route. */
     void Start(RouteMapOverlay *routemapoverlay);
     void StartAll();
-    /* Stop the computation of the selected routes. */
+    /* Stop the computation of the specified route. */
     void Stop(RouteMapOverlay *routemapoverlay);
     /* Stop the computation of all routes. */
     void StopAll();


### PR DESCRIPTION
This is a partial enhancement for issue #172: When user clicks "Stop", it stops the computation of the selected routes, and does not reset the computation of other routes.