### PR TITLE
Log polar error code, Log polar parsing warnings + polar parsing logic when value is zero

### DIFF
--- a/include/Polar.h
+++ b/include/Polar.h
@@ -51,7 +51,8 @@ enum class PolarErrorCode {
     EmptyPolarData,        // The polar file contains no data.
     WindAngleOutOfRange,   // The input heading is out of the polar range, either too much upwind or too much downwind.
     WindSpeedOutOfBounds,  // The input wind speed is either below the minimum polar wind or above the maximum polar wind.
-    NegativeBoatSpeed      // The calculated boat speed is negative.
+    NegativeBoatSpeed,     // The calculated boat speed is negative.
+    BoatSpeedNaNValue      // The polar data contains NaN boat speed value.
 };
 
 class Polar
@@ -118,7 +119,9 @@ private:
     }; // num_wind_speeds
     bool VMGAngle(SailingWindSpeed &ws1, SailingWindSpeed &ws2, float VW, float &W);
 
+    // The true wind speed for each wind angle in 'degree_steps'.
     std::vector<SailingWindSpeed> wind_speeds;
+    // The values of the true wind angle for which true wind speed is reported.
     std::vector<double> degree_steps;
     unsigned int degree_step_index[DEGREES];
 };

--- a/include/Polar.h
+++ b/include/Polar.h
@@ -44,6 +44,16 @@ class Boat;
 
 #define DEGREES 360
 
+// Error codes when Polar::Speed returns NaN.
+enum class PolarErrorCode {
+    None,                  // No error has occurred.
+    NegativeWindSpeed,     // The input true wind speed is negative.
+    EmptyPolarData,        // The polar file contains no data.
+    WindAngleOutOfRange,   // The input heading is out of the polar range, either too much upwind or too much downwind.
+    WindSpeedOutOfBounds,  // The input wind speed is either below the minimum polar wind or above the maximum polar wind.
+    NegativeBoatSpeed      // The calculated boat speed is negative.
+};
+
 class Polar
 {
 public:
@@ -63,7 +73,7 @@ public:
     void OptimizeTackingSpeeds();
     void ClosestVWi(double VW, int &VW1i, int &VW2i);
 
-    double Speed(double W, double VW, bool bound=false, bool optimize_tacking=false);
+    double Speed(double W, double VW, bool bound=false, bool optimize_tacking=false, PolarErrorCode* error_code=NULL);
     double SpeedAtApparentWindDirection(double A, double VW, double *pW=0);
     double SpeedAtApparentWindSpeed(double W, double VA);
     double SpeedAtApparentWind(double A, double VA, double *pW=0);

--- a/include/Polar.h
+++ b/include/Polar.h
@@ -52,7 +52,7 @@ enum class PolarErrorCode {
     WindAngleOutOfRange,   // The input heading is out of the polar range, either too much upwind or too much downwind.
     WindSpeedOutOfBounds,  // The input wind speed is either below the minimum polar wind or above the maximum polar wind.
     NegativeBoatSpeed,     // The calculated boat speed is negative.
-    BoatSpeedNaNValue      // The polar data contains NaN boat speed value.
+    BoatSpeedNaNValue      // The polar data contains NaN boat speed value, which represents unknown speed.
 };
 
 class Polar

--- a/include/Polar.h
+++ b/include/Polar.h
@@ -113,8 +113,8 @@ private:
         SailingWindSpeed(double nVW) : VW(nVW) {}
 
         float VW;
-        std::vector<float> speeds; // by degree_count
-        std::vector<float> orig_speeds; // by degree_count, from polar file
+        std::vector<float> speeds;      // by degree_count
+        std::vector<float> orig_speeds; // by degree_count, from polar file.
         SailingVMG VMG;
     }; // num_wind_speeds
     bool VMGAngle(SailingWindSpeed &ws1, SailingWindSpeed &ws2, float VW, float &W);

--- a/src/Polar.cpp
+++ b/src/Polar.cpp
@@ -572,7 +572,7 @@ double Polar::Speed(double W, double VW, bool bound, bool optimize_tacking, Pola
         // with faulty polars, extrapolation, sometimes results in negative boat speed
         if (error_code) *error_code = PolarErrorCode::NegativeBoatSpeed;
         return NAN;
-    } else if (VB == NAN) {
+    } else if (isnan(VB)) {
         // This happens if the Polar contains NAN values.
         if (error_code) *error_code = PolarErrorCode::BoatSpeedNaNValue;
         return NAN;

--- a/src/Polar.cpp
+++ b/src/Polar.cpp
@@ -304,6 +304,7 @@ bool Polar::Open(const wxString &filename, wxString &message)
                                         "To specify interpolated, leave blank values.\n"
                                         "To specify course as 'invalid' use 0.0 rather than 0\n"));
                         warn_zeros = true;
+                        s = 0;
                     } else if(*token) {
                         s = strtod(token, 0);
                         if(s < .05)
@@ -326,6 +327,8 @@ bool Polar::Open(const wxString &filename, wxString &message)
     UpdateSpeeds();
 
     FileName = wxString::FromUTF8(filename);
+    if (message != wxEmptyString)
+        wxLogMessage(message);
     return true;
     
 failed:
@@ -568,6 +571,10 @@ double Polar::Speed(double W, double VW, bool bound, bool optimize_tacking, Pola
     if(VB < 0) {
         // with faulty polars, extrapolation, sometimes results in negative boat speed
         if (error_code) *error_code = PolarErrorCode::NegativeBoatSpeed;
+        return NAN;
+    } else if (VB == NAN) {
+        // This happens if the Polar contains NAN values.
+        if (error_code) *error_code = PolarErrorCode::BoatSpeedNaNValue;
         return NAN;
     }
 

--- a/src/Polar.cpp
+++ b/src/Polar.cpp
@@ -304,7 +304,7 @@ bool Polar::Open(const wxString &filename, wxString &message)
                                         "To specify interpolated, leave blank values.\n"
                                         "To specify course as 'invalid' use 0.0 rather than 0\n"));
                         warn_zeros = true;
-                        s = 0;
+                        // Intentionally set s = NAN. This is to indicate the boat speed is unknow.
                     } else if(*token) {
                         s = strtod(token, 0);
                         if(s < .05)

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -867,8 +867,6 @@ bool Position::Propagate(IsoRouteList &routelist, RouteMapConfiguration &configu
             d2 *= cos(deg2rad(dlat))/2; // correct for latitude
             bearing = rad2deg(atan2(d2, d1));
 
-            //double bearing, dist2end;
-            //ll_gc_ll_reverse(configuration.EndLat, configuration.EndLon, lat, lon, &bearing, &dist2end);
             if(fabs(heading_resolve(configuration.StartEndBearing - bearing)) > configuration.MaxCourseAngle)
                 continue;
         }


### PR DESCRIPTION
# Problem statement
1. When the polar contains a zero value, a parsing warning is created, but no log is generated in opencpn.log. This makes it more difficult to troubleshoot problems.
2. When the above issue occurs, the first element of the `Polar::wind_speed` is set to `NaN`. It seems it should be set to zero.
3. When the first element of the `Polar::wind_speed` is set to `NaN`, the `Polar::Speed` function may return `Nan`, and a message is printed to stdout. It should probably have been logged to opencpn.log, which makes it easier to troubleshoot.

Example print statements to `stdout` when polar contains NaN:
```bash
polar failed bad! 18.487259 7.997830 21.487259 nan
polar failed bad! 18.487259 7.997830 24.487259 nan
polar failed bad! 18.487259 7.997830 27.487259 nan
polar failed bad! 18.487259 7.997830 30.487259 nan
polar failed bad! 18.487259 7.997830 33.487259 nan
polar failed bad! 18.487259 7.997830 36.487259 nan
polar failed bad! 18.487259 7.997830 39.487259 nan
```

# Changes in this PR
1. When the plugin opens a polar and warning-level parse issues are found, log the parse warnings to `opencpn.log`. This is useful for troubleshooting route calculation issues. For example: 
```
11:32:18.975 MESSAGE Polar.cpp:331 Test-TWS-0-20+60.pol line 2: Warning: 0 values found in polar.
These measurements will be interpolated.
To specify interpolated, leave blank values.
To specify course as 'invalid' use 0.0 rather than 0
```

5. When a polar contains the 0 value, initialize the first element of the `Polar::wind_speed` array with the `0` value instead of `NaN`.
   1. Perhaps setting the first element of the  `Polar::wind_speed` array to `NaN` was intentional?? See analysis below.
   1. When a route is calculated based on polars that contain the zero value, this ends up causing the route calculation to fail.

6. When route calculation fails, use `wxLogMessage` instead of `printf` to report the problem. Improve the message to make it easier to troubleshoot the issue.


With this PR, the print statements are now written to `opencpn.log`:
```
10:58:31.752 MESSAGE ocpn_frame.cpp:5590 LOGBOOK:  2024-07-07 17:58:31 UTC  DR Lat   33.35800 Lon  -79.28200
10:58:59.467 WARNING RouteMap.cpp:673 polar failed. V: 18.487259 VW: 7.997830 B: 21.487259 VB: nan H: 3.000000. Error: 6
10:58:59.467 WARNING RouteMap.cpp:673 polar failed. V: 18.487259 VW: 7.997830 B: 24.487259 VB: nan H: 6.000000. Error: 6
10:58:59.467 WARNING RouteMap.cpp:673 polar failed. V: 18.487259 VW: 7.997830 B: 27.487259 VB: nan H: 9.000000. Error: 6
10:58:59.467 WARNING RouteMap.cpp:673 polar failed. V: 18.487259 VW: 7.997830 B: 30.487259 VB: nan H: 12.000000. Error: 6
10:58:59.467 WARNING RouteMap.cpp:673 polar failed. V: 18.487259 VW: 7.997830 B: 33.487259 VB: nan H: 15.000000. Error: 6
```

# Analysis

When a polar is loaded, some warnings are generated with `PARSE_WARNING`, but these warnings are not necessarily displayed anywhere. The warnings are not logged in opencpn.log either. This can make route failure harder to understand.

In particular, when a polar file contains a 0 value, `Polar::Open` adds the `NaN` value to the first entry in the `Polar::wind_speeds` array. For example, given the following polar:

```
twa/tws;6;8;10;12;14;16;20;60
0;0;0;0;0;0;0;0;0
50;5.4;6.5;7.1;7.4;7.5;7.6;7.8;0
```

The `Polar::wind_speeds` array is populated as `[NaN, 5.4, 5.6, 6, 6.1, 6, 5.6, 5.0, 4.3]`
Relevant code: https://github.com/seandepagnier/weather_routing_pi/blob/97f2a08dfb06b4847d9790b11b6155d3bca5efd2/src/Polar.cpp#L299-L315

The `NaN` value in the `wind_speeds` array ends up causing `Polar::Speed()` to return `VB=NaN` at https://github.com/seandepagnier/weather_routing_pi/blob/97f2a08dfb06b4847d9790b11b6155d3bca5efd2/src/Polar.cpp#L537


