### PR TITLE
Use wxSpinCtrlDouble for "ByDegrees" and "SafetyMarginLand" parameters

### DIFF
--- a/WeatherRouting.fbp
+++ b/WeatherRouting.fbp
@@ -8500,7 +8500,7 @@
                                                                             <property name="minimize_button">0</property>
                                                                             <property name="minimum_size"></property>
                                                                             <property name="moveable">1</property>
-                                                                            <property name="name">m_tByDegrees</property>
+                                                                            <property name="name">m_sByDegrees</property>
                                                                             <property name="pane_border">1</property>
                                                                             <property name="pane_position"></property>
                                                                             <property name="pane_size"></property>

--- a/include/ConfigurationDialog.h
+++ b/include/ConfigurationDialog.h
@@ -72,7 +72,10 @@ protected:
         wxDynamicCast(event.GetEventObject(), wxSpinCtrl)->Enable();
         event.Skip();
     }
-
+    void EnableSpinDouble( wxMouseEvent& event ) {
+        wxDynamicCast(event.GetEventObject(), wxSpinCtrlDouble)->Enable();
+        event.Skip();
+    }
     void OnAvoidCyclones( wxCommandEvent& event );
     void OnAddDegreeStep( wxCommandEvent& event );
     void OnRemoveDegreeStep( wxCommandEvent& event );

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -300,7 +300,7 @@ class ConfigurationDialogBase : public wxDialog
 		wxSpinCtrl* m_sTackingTime;
 		wxStaticText* m_staticText121;
 		wxStaticText* m_staticText241;
-		wxSpinCtrl* m_sSafetyMarginLand;
+		wxSpinCtrlDouble* m_sSafetyMarginLand;
 		wxStaticText* m_staticText1211;
 		wxStaticText* m_staticText113;
 		wxStaticText* m_staticText115;

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -331,7 +331,7 @@ class ConfigurationDialogBase : public wxDialog
 		wxCheckBox* m_cbAvoidCycloneTracks;
 		wxSpinCtrl* m_sFromDegree; // Minimum course relative to true wind.
 		wxSpinCtrl* m_sToDegree;   // Maximum course relative to true wind.
-		wxSpinCtrl* m_sByDegrees;  // The increment course angle when calculating a isochrone route.
+		wxSpinCtrlDouble* m_sByDegrees;  // The increment course angle when calculating a isochrone route.
 
 		ConfigurationDialogBase( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Weather Routing Configuration"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
 		~ConfigurationDialogBase();

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -325,13 +325,13 @@ class ConfigurationDialogBase : public wxDialog
 
 	public:
 		wxDatePickerCtrl* m_dpStartDate;
-		wxCheckBox* m_cbCurrents;
+		wxCheckBox* m_cbCurrents; // specify whether to use currents or not.
 		wxCheckBox* m_cbUseGrib;
 		wxChoice* m_cClimatologyType;
 		wxCheckBox* m_cbAvoidCycloneTracks;
-		wxSpinCtrl* m_sFromDegree;
-		wxSpinCtrl* m_sToDegree;
-		wxTextCtrl* m_tByDegrees;
+		wxSpinCtrl* m_sFromDegree; // Minimum course relative to true wind.
+		wxSpinCtrl* m_sToDegree;   // Maximum course relative to true wind.
+		wxSpinCtrl* m_sByDegrees;  // 
 
 		ConfigurationDialogBase( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Weather Routing Configuration"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
 		~ConfigurationDialogBase();

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -317,6 +317,7 @@ class ConfigurationDialogBase : public wxDialog
 		virtual void OnBoatFilename( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnEditBoat( wxCommandEvent& event ) { event.Skip(); }
 		virtual void EnableSpin( wxMouseEvent& event ) { event.Skip(); }
+		virtual void EnableSpinDouble( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnUpdateSpin( wxSpinEvent& event ) { event.Skip(); }
 		virtual void OnClose( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnAvoidCyclones( wxCommandEvent& event ) { event.Skip(); }

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -331,7 +331,7 @@ class ConfigurationDialogBase : public wxDialog
 		wxCheckBox* m_cbAvoidCycloneTracks;
 		wxSpinCtrl* m_sFromDegree; // Minimum course relative to true wind.
 		wxSpinCtrl* m_sToDegree;   // Maximum course relative to true wind.
-		wxSpinCtrl* m_sByDegrees;  // 
+		wxSpinCtrl* m_sByDegrees;  // The increment course angle when calculating a isochrone route.
 
 		ConfigurationDialogBase( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Weather Routing Configuration"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
 		~ConfigurationDialogBase();

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -220,7 +220,7 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
 
     SET_SPIN(FromDegree);
     SET_SPIN(ToDegree);
-    SET_CONTROL_VALUE(wxString::Format(_T("%f"), (*it).ByDegrees), m_tByDegrees, SetValue, wxString, _T(""));
+    SET_SPIN(ByDegrees);
 
     SET_CHOICE_VALUE(Integrator, ((*it).Integrator == RouteMapConfiguration::RUNGE_KUTTA ?
                                   _T("Runge Kutta") : _T("Newton")));
@@ -309,7 +309,7 @@ void ConfigurationDialog::OnResetAdvanced( wxCommandEvent& event )
 
     m_sFromDegree->SetValue(0);
     m_sToDegree->SetValue(180);
-    m_tByDegrees->SetValue(_T("5"));
+    m_sByDegrees->SetValue(5);
 
     m_bBlockUpdate = false;
     Update();
@@ -462,8 +462,7 @@ void ConfigurationDialog::Update()
 
         GET_SPIN(FromDegree);
         GET_SPIN(ToDegree);
-        if(!m_tByDegrees->GetValue().empty())
-            m_tByDegrees->GetValue().ToDouble(&configuration.ByDegrees);
+        GET_SPIN(ByDegrees);
 
         (*it)->SetConfiguration(configuration);
 
@@ -476,8 +475,7 @@ void ConfigurationDialog::Update()
             refresh = true; // update drawing
     }
 
-    double by;
-    m_tByDegrees->GetValue().ToDouble(&by);
+    double by = m_sByDegrees->GetValue();
     if(m_sToDegree->GetValue() - m_sFromDegree->GetValue() < 2*by) {
         wxMessageDialog mdlg(this, _("Warning: less than 4 different degree steps specified\n"),
                              wxString(_("Weather Routing"), wxOK | wxICON_WARNING));

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -245,7 +245,7 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
     SET_CHECKBOX(AvoidCycloneTracks);
     SET_SPIN(CycloneMonths);
     SET_SPIN(CycloneDays);
-    SET_SPIN(SafetyMarginLand);
+    SET_SPIN_DECIMAL(SafetyMarginLand);
 
     SET_CHECKBOX(DetectLand);
     SET_CHECKBOX(DetectBoundary);

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -172,11 +172,11 @@ void ConfigurationDialog::OnBoatFilename( wxCommandEvent& event )
 #define SET_SPIN(FIELD) \
     SET_SPIN_VALUE(FIELD, (*it).FIELD)
 
-#define SET_SPIN_DECIMAL_VALUE(FIELD, VALUE)                                          \
+#define SET_SPIN_DOUBLE_VALUE(FIELD, VALUE)                                          \
     SET_CONTROL_VALUE(VALUE, m_s##FIELD, SetValue, double, value)
 
-#define SET_SPIN_DECIMAL(FIELD) \
-    SET_SPIN_DECIMAL_VALUE(FIELD, (*it).FIELD)
+#define SET_SPIN_DOUBLE(FIELD) \
+    SET_SPIN_DOUBLE_VALUE(FIELD, (*it).FIELD)
 
 #ifdef __OCPN__ANDROID__
 #define NO_EDITED_CONTROLS 1
@@ -226,7 +226,7 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
 
     SET_SPIN(FromDegree);
     SET_SPIN(ToDegree);
-    SET_SPIN_DECIMAL(ByDegrees);
+    SET_SPIN_DOUBLE(ByDegrees);
 
     SET_CHOICE_VALUE(Integrator, ((*it).Integrator == RouteMapConfiguration::RUNGE_KUTTA ?
                                   _T("Runge Kutta") : _T("Newton")));
@@ -245,7 +245,7 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
     SET_CHECKBOX(AvoidCycloneTracks);
     SET_SPIN(CycloneMonths);
     SET_SPIN(CycloneDays);
-    SET_SPIN_DECIMAL(SafetyMarginLand);
+    SET_SPIN_DOUBLE(SafetyMarginLand);
 
     SET_CHECKBOX(DetectLand);
     SET_CHECKBOX(DetectBoundary);

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -172,6 +172,12 @@ void ConfigurationDialog::OnBoatFilename( wxCommandEvent& event )
 #define SET_SPIN(FIELD) \
     SET_SPIN_VALUE(FIELD, (*it).FIELD)
 
+#define SET_SPIN_DECIMAL_VALUE(FIELD, VALUE)                                          \
+    SET_CONTROL_VALUE(VALUE, m_s##FIELD, SetValue, double, value)
+
+#define SET_SPIN_DECIMAL(FIELD) \
+    SET_SPIN_DECIMAL_VALUE(FIELD, (*it).FIELD)
+
 #ifdef __OCPN__ANDROID__
 #define NO_EDITED_CONTROLS 1
 #else
@@ -220,7 +226,7 @@ void ConfigurationDialog::SetConfigurations(std::list<RouteMapConfiguration> con
 
     SET_SPIN(FromDegree);
     SET_SPIN(ToDegree);
-    SET_SPIN(ByDegrees);
+    SET_SPIN_DECIMAL(ByDegrees);
 
     SET_CHOICE_VALUE(Integrator, ((*it).Integrator == RouteMapConfiguration::RUNGE_KUTTA ?
                                   _T("Runge Kutta") : _T("Newton")));
@@ -309,7 +315,7 @@ void ConfigurationDialog::OnResetAdvanced( wxCommandEvent& event )
 
     m_sFromDegree->SetValue(0);
     m_sToDegree->SetValue(180);
-    m_sByDegrees->SetValue(5);
+    m_sByDegrees->SetValue(5.0);
 
     m_bBlockUpdate = false;
     Update();

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1865,7 +1865,7 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure)
 
                 configuration.FromDegree = AttributeDouble(e, "FromDegree", 0);
                 configuration.ToDegree = AttributeDouble(e, "ToDegree", 180);
-                configuration.ByDegrees = AttributeDouble(e, "ByDegrees", 5);
+                configuration.ByDegrees = AttributeDouble(e, "ByDegrees", 5.);
 
                 if(configuration.boatFileName == lastboatFileName)
                     configuration.boat = lastboat;

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1855,7 +1855,7 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure)
                 configuration.WindStrength = AttributeDouble(e, "WindStrength", 1);
 
                 configuration.DetectLand = AttributeBool(e, "DetectLand", true);
-                configuration.SafetyMarginLand = AttributeDouble(e, "SafetyMarginLand", 2.);
+                configuration.SafetyMarginLand = AttributeDouble(e, "SafetyMarginLand", 0.);
                 configuration.DetectBoundary = AttributeBool(e, "DetectBoundary", false);
                 configuration.Currents = AttributeBool(e, "Currents", true);
                 configuration.OptimizeTacking = AttributeBool(e, "OptimizeTacking", false);

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1190,16 +1190,8 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_staticText117->Wrap( -1 );
 	bSizer3->Add( m_staticText117, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-	m_tByDegrees = new wxTextCtrl( sbCourses->GetStaticBox(), wxID_ANY, _("5"), wxDefaultPosition, wxSize( 40,-1 ), 0 );
-	#ifdef __WXGTK__
-	if ( !m_tByDegrees->HasFlag( wxTE_MULTILINE ) )
-	{
-	m_tByDegrees->SetMaxLength( 3 );
-	}
-	#else
-	m_tByDegrees->SetMaxLength( 3 );
-	#endif
-	bSizer3->Add( m_tByDegrees, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
+	m_sByDegrees = new wxSpinCtrl( sbCourses->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 1, 60, 5 );
+	bSizer3->Add( m_sByDegrees, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
 	m_staticText118 = new wxStaticText( sbCourses->GetStaticBox(), wxID_ANY, _("Degrees"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText118->Wrap( -1 );
@@ -1382,7 +1374,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_sSafetyMarginLand->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sFromDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sToDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
-	m_tByDegrees->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ConfigurationDialogBase::OnUpdate ), NULL, this );
+	m_sByDegrees->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_bResetAdvanced->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ConfigurationDialogBase::OnResetAdvanced ), NULL, this );
 }
 
@@ -1535,7 +1527,7 @@ ConfigurationDialogBase::~ConfigurationDialogBase()
 	m_sSafetyMarginLand->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sFromDegree->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sToDegree->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
-	m_tByDegrees->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ConfigurationDialogBase::OnUpdate ), NULL, this );
+	m_sByDegrees->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ConfigurationDialogBase::OnUpdate ), NULL, this );
 	m_bResetAdvanced->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ConfigurationDialogBase::OnResetAdvanced ), NULL, this );
 
 }

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1190,7 +1190,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_staticText117->Wrap( -1 );
 	bSizer3->Add( m_staticText117, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-	m_sByDegrees = new wxSpinCtrl( sbCourses->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 1, 60, 5 );
+	m_sByDegrees = new wxSpinCtrlDouble( sbCourses->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 0.1, 60.0, 5.0, 0.1 /*inc*/ );
 	bSizer3->Add( m_sByDegrees, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
 	m_staticText118 = new wxStaticText( sbCourses->GetStaticBox(), wxID_ANY, _("Degrees"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1374,7 +1374,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_sSafetyMarginLand->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sFromDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sToDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
-	m_sByDegrees->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
+	m_sByDegrees->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_bResetAdvanced->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ConfigurationDialogBase::OnResetAdvanced ), NULL, this );
 }
 
@@ -1527,7 +1527,7 @@ ConfigurationDialogBase::~ConfigurationDialogBase()
 	m_sSafetyMarginLand->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sFromDegree->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sToDegree->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
-	m_sByDegrees->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ConfigurationDialogBase::OnUpdate ), NULL, this );
+	m_sByDegrees->Disconnect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxCommandEventHandler( ConfigurationDialogBase::OnUpdate ), NULL, this );
 	m_bResetAdvanced->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ConfigurationDialogBase::OnResetAdvanced ), NULL, this );
 
 }

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1144,7 +1144,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_staticText241->Wrap( -1 );
 	fgSizer11511->Add( m_staticText241, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-	m_sSafetyMarginLand = new wxSpinCtrl( sbOptions1->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 0, 100, 0 );
+	m_sSafetyMarginLand = new wxSpinCtrlDouble( sbOptions1->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 0, 100, 0 /* initial value */, 0.1 /* inc */ );
 	fgSizer11511->Add( m_sSafetyMarginLand, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
 	m_staticText1211 = new wxStaticText( sbOptions1->GetStaticBox(), wxID_ANY, _("NM"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1371,7 +1371,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_sTackingTime->Connect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( ConfigurationDialogBase::EnableSpin ), NULL, this );
 	m_sTackingTime->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sSafetyMarginLand->Connect( wxEVT_MOTION, wxMouseEventHandler( ConfigurationDialogBase::EnableSpin ), NULL, this );
-	m_sSafetyMarginLand->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
+	m_sSafetyMarginLand->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sFromDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sToDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sByDegrees->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
@@ -1524,7 +1524,7 @@ ConfigurationDialogBase::~ConfigurationDialogBase()
 	m_sTackingTime->Disconnect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( ConfigurationDialogBase::EnableSpin ), NULL, this );
 	m_sTackingTime->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sSafetyMarginLand->Disconnect( wxEVT_MOTION, wxMouseEventHandler( ConfigurationDialogBase::EnableSpin ), NULL, this );
-	m_sSafetyMarginLand->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
+	m_sSafetyMarginLand->Disconnect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sFromDegree->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sToDegree->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sByDegrees->Disconnect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxCommandEventHandler( ConfigurationDialogBase::OnUpdate ), NULL, this );

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1144,7 +1144,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_staticText241->Wrap( -1 );
 	fgSizer11511->Add( m_staticText241, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-	m_sSafetyMarginLand = new wxSpinCtrlDouble( sbOptions1->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 0, 100, 0 /* initial value */, 0.1 /* inc */ );
+	m_sSafetyMarginLand = new wxSpinCtrlDouble( sbOptions1->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 0., 100., 0. /* initial value */, 0.1 /* inc */ );
 	fgSizer11511->Add( m_sSafetyMarginLand, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
 	m_staticText1211 = new wxStaticText( sbOptions1->GetStaticBox(), wxID_ANY, _("NM"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1190,7 +1190,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_staticText117->Wrap( -1 );
 	bSizer3->Add( m_staticText117, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-	m_sByDegrees = new wxSpinCtrlDouble( sbCourses->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 0.1, 60.0, 5.0, 0.1 /*inc*/ );
+	m_sByDegrees = new wxSpinCtrlDouble( sbCourses->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 140,-1 ), wxSP_ARROW_KEYS, 0.1, 60., 5., 0.1 /*inc*/ );
 	bSizer3->Add( m_sByDegrees, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
 	m_staticText118 = new wxStaticText( sbCourses->GetStaticBox(), wxID_ANY, _("Degrees"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1370,7 +1370,7 @@ ConfigurationDialogBase::ConfigurationDialogBase( wxWindow* parent, wxWindowID i
 	m_sTackingTime->Connect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( ConfigurationDialogBase::EnableSpin ), NULL, this );
 	m_sTackingTime->Connect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( ConfigurationDialogBase::EnableSpin ), NULL, this );
 	m_sTackingTime->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
-	m_sSafetyMarginLand->Connect( wxEVT_MOTION, wxMouseEventHandler( ConfigurationDialogBase::EnableSpin ), NULL, this );
+	m_sSafetyMarginLand->Connect( wxEVT_MOTION, wxMouseEventHandler( ConfigurationDialogBase::EnableSpinDouble ), NULL, this );
 	m_sSafetyMarginLand->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sFromDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );
 	m_sToDegree->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ConfigurationDialogBase::OnUpdateSpin ), NULL, this );


### PR DESCRIPTION
# Changes in this PR

1. **ByDegrees** parameter:
   1. Fix #303: when the user clicks "Edit" -> "Advanced", the "ByDegrees" parameter is now a spinner.
   3. The initial value (5.0) is populated, which makes it easier for users to understand what the default values are.
   4. The spinner is configured to support one digit after the decimal. This seems a bit overkill, though this helps to retain the existing behavior.
2. **SafetyMarginLand** parameter:
   1. Allow user to specify value with one digit after the decimal point. This could be useful such as when going through a narrow strait.
   2. This is done by changing the type from wxSpinCtrl to wxSpinCtrlDouble
   3. Set default value to 0.0 when XML files and `SafetyMarginLand` parameter is missing from the XML files. This most likely happens when an old XML file is loaded. The parameter was previously set to `2.0` is it was missing in the XML file. This was not consistent with the default value when the user creates a new Route, which is set to 0.0.

From the data model perspective, both parameters are already `double`, so it's just a UI change.

Minor changes: add code comments.

# Example:

![image](https://github.com/seandepagnier/weather_routing_pi/assets/16657278/73a41ba9-be18-4463-946e-62b01cfe10f2)

